### PR TITLE
fix: atomic execution status transitions to eliminate TOCTOU race

### DIFF
--- a/internal/store/postgres/queries.go
+++ b/internal/store/postgres/queries.go
@@ -37,7 +37,10 @@ SELECT status FROM executions WHERE id = $1
 `
 
 const queryUpdateExecutionStatus = `
-UPDATE executions SET status = $1 WHERE id = $2
+UPDATE executions
+SET status = $1
+WHERE id = $2
+  AND status NOT IN ('delivered', 'failed')
 `
 
 const queryInsertSchedule = `


### PR DESCRIPTION
Replace read-check-write pattern in UpdateExecutionStatus with single atomic UPDATE that includes terminal state guard in WHERE clause.

Before: SELECT status, check in Go, then UPDATE (race window ~ms)
After:  UPDATE ... WHERE status NOT IN ('delivered','failed') (atomic)

This prevents concurrent dispatchers from both reading 'emitted' and racing to write conflicting terminal states. PostgreSQL row lock serializes access, ensuring exactly one transition succeeds.