### PR TITLE
feat: add C4 production metrics and enhanced health endpoint

### DIFF
--- a/cmd/easycron/main.go
+++ b/cmd/easycron/main.go
@@ -226,7 +226,7 @@ func runServe() int {
 	// Create API handler with the same store instance
 	// Using a fixed project ID for single-tenant mode
 	projectID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
-	apiHandler := api.NewHandler(store, projectID)
+	apiHandler := api.NewHandler(store, projectID).WithHealthChecker(db)
 
 	// Start HTTP server with API handler
 	httpServer := &http.Server{
@@ -275,6 +275,9 @@ func runServe() int {
 			store,
 			bus,
 		)
+		if metricsSink != nil {
+			recon = recon.WithMetrics(metricsSink)
+		}
 		reconcilerWg.Add(1)
 		go func() {
 			defer reconcilerWg.Done()

--- a/internal/metrics/noop.go
+++ b/internal/metrics/noop.go
@@ -20,4 +20,8 @@ func (n *NoopSink) RetryAttempt(retryable bool)                                 
 func (n *NoopSink) EventsInFlightIncr()                                                       {}
 func (n *NoopSink) EventsInFlightDecr()                                                       {}
 func (n *NoopSink) BufferSizeUpdate(size int)                                                 {}
+func (n *NoopSink) BufferCapacitySet(capacity int)                                            {}
+func (n *NoopSink) BufferSaturationUpdate(saturation float64)                                 {}
 func (n *NoopSink) EmitError()                                                                {}
+func (n *NoopSink) OrphanedExecutionsUpdate(count int)                                        {}
+func (n *NoopSink) ExecutionLatencyObserve(latencySeconds float64)                            {}

--- a/internal/metrics/sink.go
+++ b/internal/metrics/sink.go
@@ -20,7 +20,13 @@ type Sink interface {
 
 	// EventBus metrics
 	BufferSizeUpdate(size int)
+	BufferCapacitySet(capacity int)
+	BufferSaturationUpdate(saturation float64)
 	EmitError()
+
+	// Observability metrics (C4)
+	OrphanedExecutionsUpdate(count int)
+	ExecutionLatencyObserve(latencySeconds float64)
 }
 
 // Outcome constants for DeliveryOutcome metric.


### PR DESCRIPTION
Add new Prometheus metrics for operational visibility:
- easycron_eventbus_buffer_saturation (0.0-1.0 gauge)
- easycron_eventbus_buffer_capacity (gauge)
- easycron_orphaned_executions (gauge, reported by reconciler)
- easycron_execution_latency_seconds (histogram, scheduled_at → delivered)

Enhance /health endpoint:
- GET /health?verbose=true returns component-level health
- Database connectivity check with 3s timeout
- Returns HTTP 503 with {"status": "degraded"} when unhealthy

Wire metrics into components:
- Event bus reports saturation on each emit
- Dispatcher records execution latency on successful delivery
- Reconciler reports orphan count each cycle

Update OPERATORS.md with:
- Prometheus metrics table with alert thresholds
- Recommended Alertmanager rules (critical/warning)
- Quick diagnosis PromQL queries
- Verbose health check documentation

Operators can now answer in <60 seconds:
- "Is the system healthy?" → GET /health?verbose=true
- "Are we losing executions?" → buffer_saturation > 0.8, orphaned_executions > 0
- "What's execution latency?" → execution_latency_seconds histogram