### PR TITLE
feat: Add configurable event bus, Docker Compose setup, and reconciler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,125 @@
 # EasyCron
 
-A distributed cron job scheduler with webhook delivery. Applications register jobs via REST API, and EasyCron delivers HTTP webhooks when jobs fire according to their cron schedules.
+**Schedule HTTP webhooks with cron expressions. No SDK, no queue, no complexity.**
+
+[![Go](https://img.shields.io/badge/Go-1.23+-00ADD8?style=flat&logo=go)](https://go.dev)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+EasyCron is a self-hosted cron-as-a-service. POST a job with a cron expression and a webhook URL — EasyCron fires HTTP callbacks on schedule with HMAC-signed payloads, automatic retries, and Prometheus metrics.
+
+## Why EasyCron?
+
+| | System cron + curl | pg_cron | Managed services (AWS EventBridge, GCP Scheduler) | **EasyCron** |
+|---|---|---|---|---|
+| **Setup** | Config files on each server | PostgreSQL extension | Cloud console / IaC | REST API |
+| **Webhook delivery** | Manual | No built-in HTTP | Yes | Yes, with HMAC signing |
+| **Retries** | Manual | No | Varies | 4 attempts with backoff |
+| **Observability** | DIY | pg_stat | Cloud metrics | Prometheus metrics |
+| **Portability** | Tied to host | Tied to PostgreSQL | Tied to cloud vendor | Self-hosted, any infra |
+| **Multi-app** | One crontab per host | One DB per cluster | Per-account | One instance, many apps |
+
+**Use EasyCron when you need:**
+- Scheduled HTTP callbacks without building your own scheduler
+- Webhook delivery with retry logic and signature verification
+- A single service that multiple applications can register jobs with
+- Prometheus-native observability for your scheduled tasks
+- Infrastructure you own and control (no vendor lock-in)
+
+## Architecture
+
+```mermaid
+flowchart LR
+    A[Your App] -->|POST /jobs| B[REST API]
+    B --> C[(PostgreSQL)]
+    C --> D[Scheduler]
+    D -->|cron tick| E[Event Bus]
+    E --> F[Dispatcher]
+    F -->|POST webhook| G[Your App]
+    F -->|retry on failure| F
+    H[Reconciler] -->|recover orphans| E
+    C --> H
+```
+
+**How it works:**
+1. Your application registers jobs via the REST API
+2. The **Scheduler** checks PostgreSQL every tick (default 30s) for jobs due to fire
+3. Fired executions are sent to an in-memory **Event Bus**
+4. The **Dispatcher** delivers webhooks with HMAC signatures and retries failures
+5. The optional **Reconciler** recovers executions that were lost (crash, buffer full)
 
 ## Quick Start
 
-1. Start PostgreSQL and create a database:
+### Option 1: Docker Compose (recommended)
+
 ```bash
-createdb easycron
+docker compose up
 ```
 
-2. Apply the schema:
+This starts PostgreSQL with the schema applied and EasyCron ready to accept jobs on `http://localhost:8080`.
+
+### Option 2: Manual Setup
+
+**Prerequisites:** Go 1.23+, PostgreSQL
+
+1. Build:
 ```bash
+go build -o easycron ./cmd/easycron
+```
+
+2. Start PostgreSQL and create a database:
+```bash
+createdb easycron
 psql easycron < schema/001_initial.sql
 ```
 
-3. Set environment variables:
+3. Run:
 ```bash
 export DATABASE_URL="postgres://localhost/easycron?sslmode=disable"
-```
-
-4. Run the server:
-```bash
 ./easycron serve
 ```
 
-5. Verify it's running:
+4. Verify:
 ```bash
 curl http://localhost:8080/health
 # {"status":"ok"}
 ```
 
+### Try It Out
+
+Create a job that fires every minute:
+
+```bash
+curl -X POST http://localhost:8080/jobs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "test-job",
+    "cron_expression": "* * * * *",
+    "timezone": "UTC",
+    "webhook_url": "https://httpbin.org/post",
+    "webhook_secret": "my-secret"
+  }'
+```
+
+Check executions after a minute:
+
+```bash
+curl http://localhost:8080/jobs/{job_id}/executions
+```
+
+> **Tip:** Use [webhook.site](https://webhook.site) or [httpbin.org/post](https://httpbin.org/post) as a test webhook receiver to see payloads arrive in real time.
+
 ## Configuration
 
-All configuration is via environment variables. No config files.
+All configuration is via environment variables. See [`.env.example`](.env.example) for a complete reference.
+
+### Essential Variables
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `DATABASE_URL` | Yes | - | PostgreSQL connection string |
-| `REDIS_ADDR` | No | - | Redis address for analytics |
 | `HTTP_ADDR` | No | `:8080` | HTTP server listen address |
 | `TICK_INTERVAL` | No | `30s` | Scheduler polling interval |
+| `REDIS_ADDR` | No | - | Redis address for analytics (optional) |
 
 ### Behavior
 
@@ -47,6 +127,20 @@ All configuration is via environment variables. No config files.
 - Invalid `TICK_INTERVAL`: Server refuses to start (exit code 2)
 - Missing `REDIS_ADDR`: Analytics disabled, server runs normally
 - Validate config without starting: `./easycron validate`
+
+> For the full list of environment variables (database pool, timeouts, metrics, reconciler), see [`.env.example`](.env.example) or run `./easycron --help`.
+
+## Production Checklist
+
+Before deploying to production, ensure:
+
+- [ ] **`RECONCILE_ENABLED=true`** — Without this, executions lost to crashes or buffer overflows are never recovered
+- [ ] **`METRICS_ENABLED=true`** — Required for observability and alerting
+- [ ] **Alert on `easycron_eventbus_buffer_saturation > 0.8`** — Event loss is imminent when the buffer fills
+- [ ] **Alert on `easycron_orphaned_executions > 0`** — Orphaned executions need investigation
+- [ ] **Webhook handlers are idempotent** — Duplicate deliveries will occur; use `X-EasyCron-Execution-ID` for deduplication
+
+> Read the full [Operator Guide](OPERATORS.md) for failure modes, capacity limits, and monitoring setup.
 
 ## API Usage
 
@@ -138,7 +232,6 @@ func verifySignature(secret string, body []byte, signature string) bool {
     mac := hmac.New(sha256.New, []byte(secret))
     mac.Write(body)
     expected := hex.EncodeToString(mac.Sum(nil))
-    // Use constant-time comparison to prevent timing attacks
     return hmac.Equal([]byte(expected), []byte(signature))
 }
 ```
@@ -200,18 +293,28 @@ No SDK required. No special dependencies. HTTP only.
 
 ## CLI Commands
 
-```
-easycron serve      Start the scheduler and dispatcher
-easycron validate   Validate configuration (no connections)
-easycron config     Print effective configuration as JSON
-easycron version    Print version information
-easycron --help     Show usage
-```
+| Command | Description |
+|---------|-------------|
+| `easycron serve` | Start the scheduler, dispatcher, and HTTP API server. This is the main command. |
+| `easycron validate` | Validate all environment variables without making any connections. Useful in CI or pre-deploy checks. Exits 0 if valid, 2 if not. |
+| `easycron config` | Print the effective configuration as JSON with secrets masked. Useful for debugging what values are active. |
+| `easycron version` | Print the version and git commit hash (set at build time via `-ldflags`). |
+| `easycron --help` | Show usage and the full list of environment variables. |
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Health check. Returns `{"status":"ok"}`. Add `?verbose=true` for component-level status. |
+| `POST` | `/jobs` | Create a new scheduled job. See [Create a Job](#create-a-job) for the request body. |
+| `GET` | `/jobs` | List all jobs. Supports `?limit=` and `?offset=` for pagination. |
+| `GET` | `/jobs/{id}/executions` | List executions for a job. Supports `?limit=` and `?offset=` for pagination. |
+| `DELETE` | `/jobs/{id}` | Delete a job by ID. |
 
 ## Building
 
 ```bash
-go build ./cmd/easycron
+go build -o easycron ./cmd/easycron
 ```
 
 With version injection:
@@ -221,4 +324,4 @@ go build -ldflags "-X main.version=v1.0.0 -X main.commit=$(git rev-parse --short
 
 ## License
 
-See LICENSE file.
+See [LICENSE](LICENSE) file.

--- a/cmd/easycron/main.go
+++ b/cmd/easycron/main.go
@@ -119,6 +119,8 @@ Environment Variables:
   HTTP_SHUTDOWN_TIMEOUT     Graceful HTTP shutdown timeout (default: "10s")
   DISPATCHER_DRAIN_TIMEOUT  Dispatcher event drain timeout (default: "30s")
 
+  EVENTBUS_BUFFER_SIZE      Event bus channel buffer capacity (default: "100")
+
   METRICS_ENABLED           Enable Prometheus metrics (default: "false")
   METRICS_PATH              Metrics endpoint path (default: "/metrics")
 
@@ -177,7 +179,7 @@ func runServe() int {
 	if metricsSink != nil {
 		busOpts = append(busOpts, channel.WithMetrics(metricsSink))
 	}
-	bus := channel.NewEventBus(100, busOpts...)
+	bus := channel.NewEventBus(cfg.EventBusBufferSize, busOpts...)
 
 	sched := scheduler.New(
 		scheduler.Config{TickInterval: cfg.TickInterval},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: easycron
+      POSTGRES_USER: easycron
+      POSTGRES_PASSWORD: easycron
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./schema/001_initial.sql:/docker-entrypoint-initdb.d/001_initial.sql
+      - ./schema/002_add_indexes.sql:/docker-entrypoint-initdb.d/002_add_indexes.sql
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U easycron"]
+      interval: 2s
+      timeout: 5s
+      retries: 5
+
+  easycron:
+    build: .
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://easycron:easycron@postgres:5432/easycron?sslmode=disable
+      HTTP_ADDR: ":8080"
+      RECONCILE_ENABLED: "true"
+      METRICS_ENABLED: "true"
+    ports:
+      - "8080:8080"
+
+volumes:
+  pgdata:

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -21,6 +21,18 @@ var defaultBackoff = []time.Duration{
 
 const maxAttempts = 4
 
+// MaxRetryDuration returns the worst-case total time the dispatcher may spend
+// retrying a single execution (sum of all backoff intervals). Callers such as
+// the reconciler use this to avoid re-emitting executions that are still
+// in-flight.
+func MaxRetryDuration() time.Duration {
+	var total time.Duration
+	for _, d := range defaultBackoff {
+		total += d
+	}
+	return total
+}
+
 // ErrStatusTransitionDenied is returned when a status update would regress
 // from a terminal state (delivered/failed).
 var ErrStatusTransitionDenied = errors.New("status transition denied: execution already in terminal state")

--- a/schema/002_add_indexes.sql
+++ b/schema/002_add_indexes.sql
@@ -1,0 +1,8 @@
+-- 002_add_indexes.sql
+-- Add performance indexes based on query usage patterns
+
+CREATE INDEX IF NOT EXISTS idx_jobs_enabled ON jobs(enabled);
+CREATE INDEX IF NOT EXISTS idx_jobs_project_id ON jobs(project_id);
+CREATE INDEX IF NOT EXISTS idx_executions_status_created_at ON executions(status, created_at);
+CREATE INDEX IF NOT EXISTS idx_executions_job_id ON executions(job_id);
+CREATE INDEX IF NOT EXISTS idx_delivery_attempts_execution_id ON delivery_attempts(execution_id);


### PR DESCRIPTION
safety threshold

  - Make event bus buffer size configurable via EVENTBUS_BUFFER_SIZE env var (previously hardcoded to 100)
  - Derive reconciler threshold from dispatcher's max retry duration + safety margin to prevent duplicate webhook deliveries
  - Add MaxRetryDuration() to dispatcher for cross-component coordination
  - Add docker-compose.yml for local development with PostgreSQL
  - Add database performance indexes (002_add_indexes.sql)
  - Rewrite README with architecture diagram, comparison table, production checklist, and API reference
  - Add tests for event bus config, reconciler threshold safety invariant