### PR TITLE
fix: dispatcher worker starvation, webhook payload, and API key scopes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     environment:
       DATABASE_URL: postgres://easycron:easycron@postgres:5432/easycron?sslmode=disable
       HTTP_ADDR: ":8080"
+      TICK_INTERVAL: "5s"
+      DISPATCHER_WORKERS: "4"
       RECONCILE_ENABLED: "true"
       METRICS_ENABLED: "true"
     ports:

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -86,6 +86,7 @@ type WebhookRequest struct {
 
 type WebhookPayload struct {
 	JobID       string `json:"job_id"`
+	JobName     string `json:"job_name"`
 	ExecutionID string `json:"execution_id"`
 	ScheduledAt string `json:"scheduled_at"`
 	FiredAt     string `json:"fired_at"`
@@ -312,6 +313,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, event domain.TriggerEvent) er
 
 	payload := WebhookPayload{
 		JobID:       event.JobID.String(),
+		JobName:     job.Name,
 		ExecutionID: event.ExecutionID.String(),
 		ScheduledAt: event.ScheduledAt.UTC().Format(time.RFC3339),
 		FiredAt:     event.FiredAt.UTC().Format(time.RFC3339),

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -42,12 +42,17 @@ func (s *JobService) CreateAPIKey(ctx context.Context, input CreateAPIKeyInput) 
 	tokenHash := HashToken(plaintext)
 
 	now := time.Now().UTC()
+	scopes := input.Scopes
+	if scopes == nil {
+		scopes = []string{}
+	}
+
 	key := domain.APIKey{
 		ID:        uuid.New(),
 		Namespace: ns,
 		TokenHash: tokenHash,
 		Label:     input.Label,
-		Scopes:    input.Scopes,
+		Scopes:    scopes,
 		Enabled:   true,
 		CreatedAt: now,
 	}


### PR DESCRIPTION
- Set DISPATCHER_WORKERS=4 and TICK_INTERVAL=5s in docker-compose
- Add job_name to webhook payload so receivers see names instead of UUIDs
- Default nil scopes to empty slice to prevent NOT NULL constraint violation