### PR TITLE
fix(api): implement pending acknowledgement endpoints

### DIFF
--- a/internal/api/handler_v2.go
+++ b/internal/api/handler_v2.go
@@ -352,11 +352,29 @@ func (s *ServerImpl) GetExecution(ctx context.Context, request GetExecutionReque
 	return GetExecution200JSONResponse(domainExecutionToAPI(exec)), nil
 }
 
-func (s *ServerImpl) ListPendingAck(_ context.Context, _ ListPendingAckRequestObject) (ListPendingAckResponseObject, error) {
-	return ListPendingAck200JSONResponse{Executions: []Execution{}}, nil
+func (s *ServerImpl) ListPendingAck(ctx context.Context, request ListPendingAckRequestObject) (ListPendingAckResponseObject, error) {
+	params := request.Params
+	limit := 0
+	if params.Limit != nil {
+		limit = *params.Limit
+	}
+
+	execs, err := s.svc.ListPendingAck(ctx, params.JobId, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	return ListPendingAck200JSONResponse{Executions: domainExecutionsToAPI(execs)}, nil
 }
 
-func (s *ServerImpl) AckExecution(_ context.Context, _ AckExecutionRequestObject) (AckExecutionResponseObject, error) {
+func (s *ServerImpl) AckExecution(ctx context.Context, request AckExecutionRequestObject) (AckExecutionResponseObject, error) {
+	if err := s.svc.AckExecution(ctx, request.Id); err != nil {
+		he := mapDomainError(err)
+		if he.Status == 404 {
+			return AckExecution404JSONResponse(newErrorResponse(he)), nil
+		}
+		return nil, err
+	}
 	return AckExecution204Response{}, nil
 }
 

--- a/internal/api/handler_v2_test.go
+++ b/internal/api/handler_v2_test.go
@@ -103,6 +103,8 @@ type mockExecRepo struct {
 	getExecutionFn          func(ctx context.Context, id uuid.UUID) (domain.Execution, error)
 	getExecutionScopedFn    func(ctx context.Context, id uuid.UUID, ns domain.Namespace) (domain.Execution, error)
 	listExecutionsFn        func(ctx context.Context, filter domain.ExecutionFilter) ([]domain.Execution, error)
+	listPendingAckFn        func(ctx context.Context, ns domain.Namespace, jobID *uuid.UUID, limit int) ([]domain.Execution, error)
+	ackExecutionFn          func(ctx context.Context, id uuid.UUID, ns domain.Namespace) error
 	getRecentExecutionsFn   func(ctx context.Context, jobID uuid.UUID, limit int) ([]domain.Execution, error)
 	updateExecutionStatusFn func(ctx context.Context, id uuid.UUID, status domain.ExecutionStatus) error
 	dequeueExecutionFn      func(ctx context.Context) (*domain.Execution, error)
@@ -133,6 +135,18 @@ func (m *mockExecRepo) ListExecutions(ctx context.Context, filter domain.Executi
 		return m.listExecutionsFn(ctx, filter)
 	}
 	return nil, nil
+}
+func (m *mockExecRepo) ListPendingAck(ctx context.Context, ns domain.Namespace, jobID *uuid.UUID, limit int) ([]domain.Execution, error) {
+	if m.listPendingAckFn != nil {
+		return m.listPendingAckFn(ctx, ns, jobID, limit)
+	}
+	return nil, nil
+}
+func (m *mockExecRepo) AckExecution(ctx context.Context, id uuid.UUID, ns domain.Namespace) error {
+	if m.ackExecutionFn != nil {
+		return m.ackExecutionFn(ctx, id, ns)
+	}
+	return nil
 }
 func (m *mockExecRepo) GetRecentExecutions(ctx context.Context, jobID uuid.UUID, limit int) ([]domain.Execution, error) {
 	if m.getRecentExecutionsFn != nil {
@@ -286,9 +300,9 @@ func newTestServer(jr *mockJobRepo, sr *mockScheduleRepo, er *mockExecRepo, tr *
 	return NewServerImpl(svc)
 }
 
-func boolPtr(b bool) *bool       { return &b }
-func strPtr(s string) *string     { return &s }
-func intPtr(i int) *int           { return &i }
+func boolPtr(b bool) *bool    { return &b }
+func strPtr(s string) *string { return &s }
+func intPtr(i int) *int       { return &i }
 
 // fixedJob returns a domain.Job with sensible defaults for testing.
 func fixedJob(id uuid.UUID, ns string) domain.Job {
@@ -1057,6 +1071,112 @@ func TestGetExecution_NotFound(t *testing.T) {
 
 	if _, ok := resp.(GetExecution404JSONResponse); !ok {
 		t.Fatalf("expected GetExecution404JSONResponse, got %T", resp)
+	}
+}
+
+func TestListPendingAck_HappyPath(t *testing.T) {
+	jobID := uuid.New()
+	execID := uuid.New()
+	now := time.Now().UTC()
+	limit := 2
+
+	var capturedNS domain.Namespace
+	var capturedJobID *uuid.UUID
+	var capturedLimit int
+	er := &mockExecRepo{
+		listPendingAckFn: func(ctx context.Context, ns domain.Namespace, requestedJobID *uuid.UUID, limit int) ([]domain.Execution, error) {
+			capturedNS = ns
+			capturedJobID = requestedJobID
+			capturedLimit = limit
+			return []domain.Execution{
+				{
+					ID:          execID,
+					JobID:       jobID,
+					Namespace:   ns,
+					TriggerType: domain.TriggerTypeScheduled,
+					ScheduledAt: now,
+					FiredAt:     now,
+					Status:      domain.ExecutionStatusDelivered,
+					CreatedAt:   now,
+				},
+			}, nil
+		},
+	}
+	srv := newTestServer(nil, nil, er, nil, nil, nil)
+
+	resp, err := srv.ListPendingAck(ctxWithNS("t1"), ListPendingAckRequestObject{
+		Params: ListPendingAckParams{
+			Limit: &limit,
+			JobId: &jobID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, ok := resp.(ListPendingAck200JSONResponse)
+	if !ok {
+		t.Fatalf("expected ListPendingAck200JSONResponse, got %T", resp)
+	}
+	if len(got.Executions) != 1 {
+		t.Fatalf("expected 1 execution, got %d", len(got.Executions))
+	}
+	if got.Executions[0].Id != execID {
+		t.Fatalf("expected execution ID %v, got %v", execID, got.Executions[0].Id)
+	}
+	if capturedNS != "t1" {
+		t.Fatalf("expected namespace t1, got %q", capturedNS)
+	}
+	if capturedJobID == nil || *capturedJobID != jobID {
+		t.Fatalf("expected job_id filter %v, got %v", jobID, capturedJobID)
+	}
+	if capturedLimit != limit {
+		t.Fatalf("expected limit %d, got %d", limit, capturedLimit)
+	}
+}
+
+func TestAckExecution_HappyPath(t *testing.T) {
+	execID := uuid.New()
+	var capturedID uuid.UUID
+	var capturedNS domain.Namespace
+	er := &mockExecRepo{
+		ackExecutionFn: func(ctx context.Context, id uuid.UUID, ns domain.Namespace) error {
+			capturedID = id
+			capturedNS = ns
+			return nil
+		},
+	}
+	srv := newTestServer(nil, nil, er, nil, nil, nil)
+
+	resp, err := srv.AckExecution(ctxWithNS("t1"), AckExecutionRequestObject{Id: execID})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(AckExecution204Response); !ok {
+		t.Fatalf("expected AckExecution204Response, got %T", resp)
+	}
+	if capturedID != execID {
+		t.Fatalf("expected execution ID %v, got %v", execID, capturedID)
+	}
+	if capturedNS != "t1" {
+		t.Fatalf("expected namespace t1, got %q", capturedNS)
+	}
+}
+
+func TestAckExecution_NotFound(t *testing.T) {
+	er := &mockExecRepo{
+		ackExecutionFn: func(ctx context.Context, id uuid.UUID, ns domain.Namespace) error {
+			return domain.ErrExecutionNotFound
+		},
+	}
+	srv := newTestServer(nil, nil, er, nil, nil, nil)
+
+	resp, err := srv.AckExecution(ctxWithNS("t1"), AckExecutionRequestObject{Id: uuid.New()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(AckExecution404JSONResponse); !ok {
+		t.Fatalf("expected AckExecution404JSONResponse, got %T", resp)
 	}
 }
 

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -37,6 +37,8 @@ type ExecutionRepository interface {
 	// Used by the service layer for API-facing operations (defense-in-depth).
 	GetExecutionScoped(ctx context.Context, id uuid.UUID, ns Namespace) (Execution, error)
 	ListExecutions(ctx context.Context, filter ExecutionFilter) ([]Execution, error)
+	ListPendingAck(ctx context.Context, ns Namespace, jobID *uuid.UUID, limit int) ([]Execution, error)
+	AckExecution(ctx context.Context, id uuid.UUID, ns Namespace) error
 	GetRecentExecutions(ctx context.Context, jobID uuid.UUID, limit int) ([]Execution, error)
 	UpdateExecutionStatus(ctx context.Context, id uuid.UUID, status ExecutionStatus) error
 	DequeueExecution(ctx context.Context) (*Execution, error)

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -115,6 +115,8 @@ type mockExecutionRepo struct {
 	getExecutionFn          func(ctx context.Context, id uuid.UUID) (domain.Execution, error)
 	getExecutionScopedFn    func(ctx context.Context, id uuid.UUID, ns domain.Namespace) (domain.Execution, error)
 	listExecutionsFn        func(ctx context.Context, filter domain.ExecutionFilter) ([]domain.Execution, error)
+	listPendingAckFn        func(ctx context.Context, ns domain.Namespace, jobID *uuid.UUID, limit int) ([]domain.Execution, error)
+	ackExecutionFn          func(ctx context.Context, id uuid.UUID, ns domain.Namespace) error
 	getRecentExecutionsFn   func(ctx context.Context, jobID uuid.UUID, limit int) ([]domain.Execution, error)
 	updateExecutionStatusFn func(ctx context.Context, id uuid.UUID, status domain.ExecutionStatus) error
 	dequeueExecutionFn      func(ctx context.Context) (*domain.Execution, error)
@@ -148,6 +150,20 @@ func (m *mockExecutionRepo) ListExecutions(ctx context.Context, filter domain.Ex
 		return m.listExecutionsFn(ctx, filter)
 	}
 	return nil, nil
+}
+
+func (m *mockExecutionRepo) ListPendingAck(ctx context.Context, ns domain.Namespace, jobID *uuid.UUID, limit int) ([]domain.Execution, error) {
+	if m.listPendingAckFn != nil {
+		return m.listPendingAckFn(ctx, ns, jobID, limit)
+	}
+	return nil, nil
+}
+
+func (m *mockExecutionRepo) AckExecution(ctx context.Context, id uuid.UUID, ns domain.Namespace) error {
+	if m.ackExecutionFn != nil {
+		return m.ackExecutionFn(ctx, id, ns)
+	}
+	return nil
 }
 
 func (m *mockExecutionRepo) GetRecentExecutions(ctx context.Context, jobID uuid.UUID, limit int) ([]domain.Execution, error) {

--- a/internal/service/executions.go
+++ b/internal/service/executions.go
@@ -22,6 +22,28 @@ func (s *JobService) ListExecutions(ctx context.Context, filter domain.Execution
 	return s.executions.ListExecutions(ctx, filter)
 }
 
+// ListPendingAck returns terminal executions that have not been acknowledged,
+// scoped to the namespace from ctx.
+func (s *JobService) ListPendingAck(ctx context.Context, jobID *uuid.UUID, limit int) ([]domain.Execution, error) {
+	ns := domain.NamespaceFromContext(ctx)
+	if ns.IsZero() {
+		return nil, domain.ErrNamespaceRequired
+	}
+
+	params := domain.ListParams{Limit: limit}.WithDefaults()
+	return s.executions.ListPendingAck(ctx, ns, jobID, params.Limit)
+}
+
+// AckExecution marks a pending terminal execution as acknowledged.
+func (s *JobService) AckExecution(ctx context.Context, id uuid.UUID) error {
+	ns := domain.NamespaceFromContext(ctx)
+	if ns.IsZero() {
+		return domain.ErrNamespaceRequired
+	}
+
+	return s.executions.AckExecution(ctx, id, ns)
+}
+
 // GetExecution retrieves a single execution with its delivery attempts.
 func (s *JobService) GetExecution(ctx context.Context, id uuid.UUID) (domain.Execution, []domain.DeliveryAttempt, error) {
 	ns := domain.NamespaceFromContext(ctx)

--- a/internal/service/executions_test.go
+++ b/internal/service/executions_test.go
@@ -47,6 +47,102 @@ func TestListExecutions_NoNamespace(t *testing.T) {
 	}
 }
 
+func TestListPendingAck_HappyPath(t *testing.T) {
+	jobID := uuid.New()
+	var capturedNS domain.Namespace
+	var capturedJobID *uuid.UUID
+	var capturedLimit int
+	execRepo := &mockExecutionRepo{
+		listPendingAckFn: func(_ context.Context, ns domain.Namespace, jobID *uuid.UUID, limit int) ([]domain.Execution, error) {
+			capturedNS = ns
+			capturedJobID = jobID
+			capturedLimit = limit
+			return []domain.Execution{
+				{ID: uuid.New(), JobID: *jobID, Namespace: ns, Status: domain.ExecutionStatusDelivered},
+			}, nil
+		},
+	}
+	svc := newTestServiceFull(nil, nil, execRepo, nil, nil, nil)
+
+	execs, err := svc.ListPendingAck(ctxWithNS("t1"), &jobID, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(execs) != 1 {
+		t.Fatalf("expected 1 execution, got %d", len(execs))
+	}
+	if capturedNS != "t1" {
+		t.Errorf("expected namespace 't1', got %q", capturedNS)
+	}
+	if capturedJobID == nil || *capturedJobID != jobID {
+		t.Errorf("expected job ID %s, got %v", jobID, capturedJobID)
+	}
+	if capturedLimit != 10 {
+		t.Errorf("expected limit 10, got %d", capturedLimit)
+	}
+}
+
+func TestListPendingAck_DefaultsLimit(t *testing.T) {
+	var capturedLimit int
+	execRepo := &mockExecutionRepo{
+		listPendingAckFn: func(_ context.Context, ns domain.Namespace, jobID *uuid.UUID, limit int) ([]domain.Execution, error) {
+			capturedLimit = limit
+			return nil, nil
+		},
+	}
+	svc := newTestServiceFull(nil, nil, execRepo, nil, nil, nil)
+
+	_, err := svc.ListPendingAck(ctxWithNS("t1"), nil, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedLimit != 100 {
+		t.Errorf("expected default limit 100, got %d", capturedLimit)
+	}
+}
+
+func TestListPendingAck_NoNamespace(t *testing.T) {
+	svc := newTestServiceFull(nil, nil, nil, nil, nil, nil)
+
+	_, err := svc.ListPendingAck(context.Background(), nil, 10)
+	if !errors.Is(err, domain.ErrNamespaceRequired) {
+		t.Errorf("expected ErrNamespaceRequired, got %v", err)
+	}
+}
+
+func TestAckExecution_HappyPath(t *testing.T) {
+	execID := uuid.New()
+	var capturedID uuid.UUID
+	var capturedNS domain.Namespace
+	execRepo := &mockExecutionRepo{
+		ackExecutionFn: func(_ context.Context, id uuid.UUID, ns domain.Namespace) error {
+			capturedID = id
+			capturedNS = ns
+			return nil
+		},
+	}
+	svc := newTestServiceFull(nil, nil, execRepo, nil, nil, nil)
+
+	if err := svc.AckExecution(ctxWithNS("t1"), execID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedID != execID {
+		t.Errorf("expected execution ID %s, got %s", execID, capturedID)
+	}
+	if capturedNS != "t1" {
+		t.Errorf("expected namespace 't1', got %q", capturedNS)
+	}
+}
+
+func TestAckExecution_NoNamespace(t *testing.T) {
+	svc := newTestServiceFull(nil, nil, nil, nil, nil, nil)
+
+	err := svc.AckExecution(context.Background(), uuid.New())
+	if !errors.Is(err, domain.ErrNamespaceRequired) {
+		t.Errorf("expected ErrNamespaceRequired, got %v", err)
+	}
+}
+
 func TestGetExecution_HappyPath(t *testing.T) {
 	execID := uuid.New()
 	jobID := uuid.New()

--- a/internal/store/postgres/queries.go
+++ b/internal/store/postgres/queries.go
@@ -131,6 +131,15 @@ ORDER BY created_at DESC
 LIMIT $2
 `
 
+const queryAckExecution = `
+UPDATE executions
+SET acknowledged_at = NOW()
+WHERE id = $1
+  AND namespace = $2
+  AND acknowledged_at IS NULL
+  AND status IN ('delivered', 'failed')
+`
+
 const queryGetExecutionStatus = `
 SELECT status FROM executions WHERE id = $1
 `

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -560,6 +560,67 @@ LIMIT $%d OFFSET $%d
 	return scanExecutionRows(rows)
 }
 
+// ListPendingAck returns terminal executions that have not been acknowledged.
+func (s *Store) ListPendingAck(ctx context.Context, ns domain.Namespace, jobID *uuid.UUID, limit int) ([]domain.Execution, error) {
+	ctx, cancel := s.withTimeout(ctx)
+	defer cancel()
+
+	params := domain.ListParams{Limit: limit}.WithDefaults()
+
+	conditions := []string{
+		"namespace = $1",
+		"acknowledged_at IS NULL",
+		"status IN ('delivered', 'failed')",
+	}
+	args := []interface{}{string(ns)}
+	argIdx := 2
+
+	if jobID != nil && *jobID != uuid.Nil {
+		conditions = append(conditions, fmt.Sprintf("job_id = $%d", argIdx))
+		args = append(args, *jobID)
+		argIdx++
+	}
+
+	query := fmt.Sprintf(`
+SELECT id, job_id, namespace, trigger_type, scheduled_at, fired_at, status, acknowledged_at, created_at
+FROM executions
+WHERE %s
+ORDER BY created_at DESC
+LIMIT $%d
+`, strings.Join(conditions, " AND "), argIdx)
+
+	args = append(args, params.Limit)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanExecutionRows(rows)
+}
+
+// AckExecution marks a terminal unacknowledged execution as acknowledged.
+func (s *Store) AckExecution(ctx context.Context, id uuid.UUID, ns domain.Namespace) error {
+	ctx, cancel := s.withTimeout(ctx)
+	defer cancel()
+
+	result, err := s.db.ExecContext(ctx, queryAckExecution, id, string(ns))
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return domain.ErrExecutionNotFound
+	}
+
+	return nil
+}
+
 // UpdateExecutionStatus updates the status of an execution.
 // Returns dispatcher.ErrStatusTransitionDenied if the execution is already in a terminal state.
 // This uses an atomic UPDATE with WHERE clause to prevent TOCTOU race conditions.


### PR DESCRIPTION
## What

Implements the advertised pending acknowledgement execution endpoints.

## Why

The API exposed `GET /executions/pending-ack` and `POST /executions/{id}/ack`, but both handlers were stubs. This made agent/client acknowledgement workflows unusable and could cause delivered or failed executions to remain pending forever.

## How

- Added namespace-scoped service and repository methods for pending acknowledgement reads and acknowledgement updates.
- Implemented `GET /executions/pending-ack` with optional `job_id` and `limit` support.
- Implemented `POST /executions/{id}/ack` to update `acknowledged_at` only for terminal, unacknowledged executions in the caller’s namespace.
- Added API and service tests covering happy paths, namespace scoping, default limits, and not-found behavior.

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Race detector clean (`go test -race ./...`)
- [x] Documentation updated (if applicable)
- [x] No new security concerns (SSRF, injection, credential exposure)
