### PR TITLE
test(api): cover manual trigger dispatch events

### DIFF
--- a/internal/api/handler_v2_test.go
+++ b/internal/api/handler_v2_test.go
@@ -271,6 +271,17 @@ func (m *mockHealthCheckerV2) PingContext(ctx context.Context) error {
 	return m.pingErr
 }
 
+type mockEmitterV2 struct {
+	lastEvent domain.TriggerEvent
+	called    bool
+}
+
+func (m *mockEmitterV2) Emit(ctx context.Context, event domain.TriggerEvent) error {
+	m.called = true
+	m.lastEvent = event
+	return nil
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 func ctxWithNS(ns string) context.Context {
@@ -827,6 +838,42 @@ func TestTriggerJob_HappyPath(t *testing.T) {
 	}
 	if got.TriggerType != ExecutionTriggerTypeManual {
 		t.Fatalf("expected trigger type %q, got %q", ExecutionTriggerTypeManual, got.TriggerType)
+	}
+}
+
+func TestTriggerJob_EmitsEventWhenEmitterAttached(t *testing.T) {
+	jobID := uuid.New()
+	jr := &mockJobRepo{
+		getJobWithScheduleFn: func(ctx context.Context, id uuid.UUID) (domain.Job, domain.Schedule, error) {
+			return fixedJob(jobID, "t1"), fixedSchedule(uuid.New()), nil
+		},
+	}
+	er := &mockExecRepo{}
+	emitter := &mockEmitterV2{}
+	svc := service.NewJobService(jr, &mockScheduleRepo{}, er, &mockTagRepo{}, &mockAPIKeyRepoV2{}, &mockAttemptRepo{}, cron.NewParser()).
+		WithEmitter(emitter)
+	srv := NewServerImpl(svc)
+
+	resp, err := srv.TriggerJob(ctxWithNS("t1"), TriggerJobRequestObject{Id: jobID})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, ok := resp.(TriggerJob201JSONResponse)
+	if !ok {
+		t.Fatalf("expected TriggerJob201JSONResponse, got %T", resp)
+	}
+	if !emitter.called {
+		t.Fatal("expected manual trigger to emit dispatch event")
+	}
+	if emitter.lastEvent.ExecutionID != got.Id {
+		t.Fatalf("expected emitted execution ID %v, got %v", got.Id, emitter.lastEvent.ExecutionID)
+	}
+	if emitter.lastEvent.JobID != jobID {
+		t.Fatalf("expected emitted job ID %v, got %v", jobID, emitter.lastEvent.JobID)
+	}
+	if emitter.lastEvent.Namespace != "t1" {
+		t.Fatalf("expected emitted namespace t1, got %q", emitter.lastEvent.Namespace)
 	}
 }
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -249,6 +249,17 @@ func (m *mockAttemptRepo) GetAttempts(ctx context.Context, executionID uuid.UUID
 	return nil, nil
 }
 
+type mockEmitter struct {
+	lastEvent domain.TriggerEvent
+	called    bool
+}
+
+func (m *mockEmitter) Emit(ctx context.Context, event domain.TriggerEvent) error {
+	m.called = true
+	m.lastEvent = event
+	return nil
+}
+
 // ── Test helpers ────────────────────────────────────────────────────────────
 
 func newTestService(jr *mockJobRepo, sr *mockScheduleRepo, er *mockExecutionRepo, tr *mockTagRepo) *service.JobService {
@@ -910,6 +921,50 @@ func TestHandleTriggerJob_HappyPath(t *testing.T) {
 	}
 	if !strings.Contains(text, "manual") {
 		t.Errorf("expected trigger_type manual in result, got: %s", text)
+	}
+}
+
+func TestHandleTriggerJob_EmitsEventWhenEmitterAttached(t *testing.T) {
+	job := fixedJob()
+	job.Enabled = true
+	schedule := fixedSchedule()
+
+	jr := &mockJobRepo{
+		getJobWithScheduleFn: func(_ context.Context, _ uuid.UUID) (domain.Job, domain.Schedule, error) {
+			return job, schedule, nil
+		},
+	}
+	emitter := &mockEmitter{}
+	svc := newTestService(jr, nil, nil, nil).WithEmitter(emitter)
+	handler := handleTriggerJob(svc)
+
+	req := mcpgo.CallToolRequest{
+		Params: mcpgo.CallToolParams{
+			Name: "trigger-job",
+			Arguments: map[string]any{
+				"id": job.ID.String(),
+			},
+		},
+	}
+
+	result, err := handler(ctxWithNS("t1"), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", resultText(t, result))
+	}
+	if !emitter.called {
+		t.Fatal("expected MCP manual trigger to emit dispatch event")
+	}
+	if emitter.lastEvent.JobID != job.ID {
+		t.Fatalf("expected emitted job ID %v, got %v", job.ID, emitter.lastEvent.JobID)
+	}
+	if emitter.lastEvent.Namespace != "t1" {
+		t.Fatalf("expected emitted namespace t1, got %q", emitter.lastEvent.Namespace)
+	}
+	if emitter.lastEvent.ExecutionID == uuid.Nil {
+		t.Fatal("expected emitted execution ID")
 	}
 }
 


### PR DESCRIPTION
## What

Adds regression coverage for manual trigger dispatch events in both REST and MCP trigger paths.

## Why

Manual triggers must enqueue a dispatch event in channel mode so webhooks are delivered immediately instead of waiting for reconciliation. The production path was already wired, and these tests prevent that behavior from regressing.

## How

- Added REST handler coverage showing `POST /jobs/{id}/trigger` emits a `TriggerEvent` when an emitter is attached.
- Added MCP handler coverage showing `trigger-job` emits a `TriggerEvent` through the same service path.
- Verified emitted event metadata includes execution ID, job ID, and namespace.

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Race detector clean (`go test -race ./...`)
- [x] Documentation updated (if applicable)
- [x] No new security concerns (SSRF, injection, credential exposure)
