### PR TITLE
Protect metrics endpoint by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,9 @@ METRICS_ENABLED=false
 # Path for the metrics endpoint
 METRICS_PATH=/metrics
 
+# Allow unauthenticated metrics access
+METRICS_PUBLIC=false
+
 # Reconciler (recommended for production)
 # The reconciler recovers orphaned executions (lost to crashes or buffer overflow).
 # Without it, orphaned executions are permanently lost.

--- a/cmd/cronlite/main.go
+++ b/cmd/cronlite/main.go
@@ -142,6 +142,7 @@ Environment Variables:
 
   METRICS_ENABLED           Enable Prometheus metrics (default: "false")
   METRICS_PATH              Metrics endpoint path (default: "/metrics")
+  METRICS_PUBLIC            Allow unauthenticated metrics access (default: "false")
 
   RECONCILE_ENABLED         Enable orphan execution reconciler (default: "false")
   RECONCILE_INTERVAL        How often to scan for orphans (default: "5m")
@@ -168,6 +169,19 @@ type leaderRuntime struct {
 	emitter     interface {
 		Emit(ctx context.Context, event domain.TriggerEvent) error
 	}
+}
+
+func newMetricsHandler(
+	appCtx context.Context,
+	keyRepo domain.APIKeyRepository,
+	fallbackKey string,
+	public bool,
+) http.Handler {
+	metricsHandler := http.Handler(promhttp.Handler())
+	if public {
+		return metricsHandler
+	}
+	return api.MultiKeyAuthMiddleware(appCtx, keyRepo, fallbackKey, metricsHandler)
 }
 
 func (lr *leaderRuntime) start(leaderCtx context.Context) {
@@ -397,11 +411,7 @@ func runServe() int {
 
 	httpMux := http.NewServeMux()
 	if cfg.MetricsEnabled {
-		metricsHandler := http.Handler(promhttp.Handler())
-		if cfg.APIKey != "" {
-			metricsHandler = api.MultiKeyAuthMiddleware(appCtx, store, cfg.APIKey, metricsHandler)
-		}
-		httpMux.Handle(cfg.MetricsPath, metricsHandler)
+		httpMux.Handle(cfg.MetricsPath, newMetricsHandler(appCtx, store, cfg.APIKey, cfg.MetricsPublic))
 	}
 	httpMux.Handle("/mcp", mcpHandler)
 	httpMux.Handle("/", rootHandler)

--- a/cmd/cronlite/metrics_handler_test.go
+++ b/cmd/cronlite/metrics_handler_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/djlord-it/cronlite/internal/domain"
+)
+
+type metricsAPIKeyRepo struct{}
+
+func (metricsAPIKeyRepo) InsertAPIKey(context.Context, domain.APIKey) error {
+	return nil
+}
+
+func (metricsAPIKeyRepo) GetKeyByTokenHash(context.Context, string) (domain.APIKey, error) {
+	return domain.APIKey{}, domain.ErrAPIKeyNotFound
+}
+
+func (metricsAPIKeyRepo) ListKeys(context.Context, domain.Namespace, domain.ListParams) ([]domain.APIKey, error) {
+	return nil, nil
+}
+
+func (metricsAPIKeyRepo) DeleteKey(context.Context, uuid.UUID, domain.Namespace) error {
+	return nil
+}
+
+func (metricsAPIKeyRepo) UpdateLastUsedAt(context.Context, []uuid.UUID) error {
+	return nil
+}
+
+func TestNewMetricsHandlerRequiresAuthWithoutLegacyAPIKey(t *testing.T) {
+	handler := newMetricsHandler(context.Background(), metricsAPIKeyRepo{}, "", false)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", w.Code)
+	}
+}
+
+func TestNewMetricsHandlerCanBeExplicitlyPublic(t *testing.T) {
+	handler := newMetricsHandler(context.Background(), metricsAPIKeyRepo{}, "", true)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code == http.StatusUnauthorized {
+		t.Fatal("expected public metrics handler to bypass auth")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	DatabaseURL string `json:"database_url"`
 	RedisAddr   string `json:"redis_addr,omitempty"`
 	HTTPAddr    string `json:"http_addr"`
-	APIKey  string `json:"-"` // never serialized, not even masked
+	APIKey      string `json:"-"` // never serialized, not even masked
 
 	TickInterval    time.Duration `json:"-"`
 	TickIntervalStr string        `json:"tick_interval"`
@@ -35,6 +35,7 @@ type Config struct {
 
 	MetricsEnabled bool   `json:"metrics_enabled"`
 	MetricsPath    string `json:"metrics_path"`
+	MetricsPublic  bool   `json:"metrics_public"`
 
 	ReconcileEnabled     bool          `json:"reconcile_enabled"`
 	ReconcileInterval    time.Duration `json:"-"`
@@ -53,9 +54,9 @@ type Config struct {
 	EventBusBufferSize int `json:"eventbus_buffer_size"`
 
 	// CircuitBreakerThreshold: 0 disables the circuit breaker.
-	CircuitBreakerThreshold  int           `json:"circuit_breaker_threshold"`
-	CircuitBreakerCooldown   time.Duration `json:"-"`
-	CircuitBreakerCooldownStr string       `json:"circuit_breaker_cooldown"`
+	CircuitBreakerThreshold   int           `json:"circuit_breaker_threshold"`
+	CircuitBreakerCooldown    time.Duration `json:"-"`
+	CircuitBreakerCooldownStr string        `json:"circuit_breaker_cooldown"`
 
 	// DispatchMode: "channel" (in-memory) or "db" (Postgres FOR UPDATE SKIP LOCKED polling).
 	DispatchMode      string        `json:"dispatch_mode"`
@@ -90,22 +91,23 @@ type Config struct {
 // Load reads configuration from environment variables with defaults.
 func Load() Config {
 	cfg := Config{
-		DatabaseURL:               os.Getenv("DATABASE_URL"),
-		RedisAddr:                 os.Getenv("REDIS_ADDR"),
-		HTTPAddr:                  os.Getenv("HTTP_ADDR"),
-		APIKey:                    os.Getenv("API_KEY"),
-		TickIntervalStr:           os.Getenv("TICK_INTERVAL"),
-		DBOpTimeoutStr:            os.Getenv("DB_OP_TIMEOUT"),
-		DBConnMaxLifetimeStr:      os.Getenv("DB_CONN_MAX_LIFETIME"),
-		DBConnMaxIdleTimeStr:      os.Getenv("DB_CONN_MAX_IDLE_TIME"),
-		HTTPShutdownTimeoutStr:    os.Getenv("HTTP_SHUTDOWN_TIMEOUT"),
-		DispatcherDrainTimeoutStr: os.Getenv("DISPATCHER_DRAIN_TIMEOUT"),
-		MetricsEnabled:            os.Getenv("METRICS_ENABLED") == "true",
-		MetricsPath:               os.Getenv("METRICS_PATH"),
-		ReconcileEnabled:          os.Getenv("RECONCILE_ENABLED") == "true",
-		ReconcileIntervalStr:          os.Getenv("RECONCILE_INTERVAL"),
-		ReconcileThresholdStr:         os.Getenv("RECONCILE_THRESHOLD"),
-		ReconcileRequeueThresholdStr:  os.Getenv("RECONCILE_REQUEUE_THRESHOLD"),
+		DatabaseURL:                  os.Getenv("DATABASE_URL"),
+		RedisAddr:                    os.Getenv("REDIS_ADDR"),
+		HTTPAddr:                     os.Getenv("HTTP_ADDR"),
+		APIKey:                       os.Getenv("API_KEY"),
+		TickIntervalStr:              os.Getenv("TICK_INTERVAL"),
+		DBOpTimeoutStr:               os.Getenv("DB_OP_TIMEOUT"),
+		DBConnMaxLifetimeStr:         os.Getenv("DB_CONN_MAX_LIFETIME"),
+		DBConnMaxIdleTimeStr:         os.Getenv("DB_CONN_MAX_IDLE_TIME"),
+		HTTPShutdownTimeoutStr:       os.Getenv("HTTP_SHUTDOWN_TIMEOUT"),
+		DispatcherDrainTimeoutStr:    os.Getenv("DISPATCHER_DRAIN_TIMEOUT"),
+		MetricsEnabled:               os.Getenv("METRICS_ENABLED") == "true",
+		MetricsPath:                  os.Getenv("METRICS_PATH"),
+		MetricsPublic:                os.Getenv("METRICS_PUBLIC") == "true",
+		ReconcileEnabled:             os.Getenv("RECONCILE_ENABLED") == "true",
+		ReconcileIntervalStr:         os.Getenv("RECONCILE_INTERVAL"),
+		ReconcileThresholdStr:        os.Getenv("RECONCILE_THRESHOLD"),
+		ReconcileRequeueThresholdStr: os.Getenv("RECONCILE_REQUEUE_THRESHOLD"),
 	}
 
 	if batchStr := os.Getenv("RECONCILE_BATCH_SIZE"); batchStr != "" {
@@ -335,67 +337,69 @@ func parseInt(s string) (int, error) {
 // MaskedJSON returns the configuration as JSON with secrets masked.
 func (c Config) MaskedJSON() ([]byte, error) {
 	masked := struct {
-		DatabaseURL            string `json:"database_url"`
-		RedisAddr              string `json:"redis_addr,omitempty"`
-		HTTPAddr               string `json:"http_addr"`
-		TickInterval           string `json:"tick_interval"`
-		DBOpTimeout            string `json:"db_op_timeout"`
-		DBMaxOpenConns         int    `json:"db_max_open_conns"`
-		DBMaxIdleConns         int    `json:"db_max_idle_conns"`
-		DBConnMaxLifetime      string `json:"db_conn_max_lifetime"`
-		DBConnMaxIdleTime      string `json:"db_conn_max_idle_time"`
-		HTTPShutdownTimeout    string `json:"http_shutdown_timeout"`
-		DispatcherDrainTimeout string `json:"dispatcher_drain_timeout"`
-		MetricsEnabled         bool   `json:"metrics_enabled"`
-		MetricsPath            string `json:"metrics_path"`
-		ReconcileEnabled       bool   `json:"reconcile_enabled"`
-		ReconcileInterval      string `json:"reconcile_interval"`
-		ReconcileThreshold         string `json:"reconcile_threshold"`
-		ReconcileRequeueThreshold  string `json:"reconcile_requeue_threshold"`
-		ReconcileBatchSize         int    `json:"reconcile_batch_size"`
-		EventBusBufferSize      int    `json:"eventbus_buffer_size"`
-		CircuitBreakerThreshold int    `json:"circuit_breaker_threshold"`
-		CircuitBreakerCooldown  string `json:"circuit_breaker_cooldown"`
-		DispatchMode             string `json:"dispatch_mode"`
-		DBPollInterval           string `json:"db_poll_interval"`
-		DispatcherWorkers        int    `json:"dispatcher_workers"`
-		LeaderLockKey            int64  `json:"leader_lock_key"`
-		LeaderRetryInterval      string `json:"leader_retry_interval"`
-		LeaderHeartbeatInterval  string `json:"leader_heartbeat_interval"`
-		MaxFiresPerTick          int    `json:"max_fires_per_tick"`
-		IPRateLimit              int    `json:"ip_rate_limit"`
-		NamespaceRateLimit       int    `json:"namespace_rate_limit"`
+		DatabaseURL               string `json:"database_url"`
+		RedisAddr                 string `json:"redis_addr,omitempty"`
+		HTTPAddr                  string `json:"http_addr"`
+		TickInterval              string `json:"tick_interval"`
+		DBOpTimeout               string `json:"db_op_timeout"`
+		DBMaxOpenConns            int    `json:"db_max_open_conns"`
+		DBMaxIdleConns            int    `json:"db_max_idle_conns"`
+		DBConnMaxLifetime         string `json:"db_conn_max_lifetime"`
+		DBConnMaxIdleTime         string `json:"db_conn_max_idle_time"`
+		HTTPShutdownTimeout       string `json:"http_shutdown_timeout"`
+		DispatcherDrainTimeout    string `json:"dispatcher_drain_timeout"`
+		MetricsEnabled            bool   `json:"metrics_enabled"`
+		MetricsPath               string `json:"metrics_path"`
+		MetricsPublic             bool   `json:"metrics_public"`
+		ReconcileEnabled          bool   `json:"reconcile_enabled"`
+		ReconcileInterval         string `json:"reconcile_interval"`
+		ReconcileThreshold        string `json:"reconcile_threshold"`
+		ReconcileRequeueThreshold string `json:"reconcile_requeue_threshold"`
+		ReconcileBatchSize        int    `json:"reconcile_batch_size"`
+		EventBusBufferSize        int    `json:"eventbus_buffer_size"`
+		CircuitBreakerThreshold   int    `json:"circuit_breaker_threshold"`
+		CircuitBreakerCooldown    string `json:"circuit_breaker_cooldown"`
+		DispatchMode              string `json:"dispatch_mode"`
+		DBPollInterval            string `json:"db_poll_interval"`
+		DispatcherWorkers         int    `json:"dispatcher_workers"`
+		LeaderLockKey             int64  `json:"leader_lock_key"`
+		LeaderRetryInterval       string `json:"leader_retry_interval"`
+		LeaderHeartbeatInterval   string `json:"leader_heartbeat_interval"`
+		MaxFiresPerTick           int    `json:"max_fires_per_tick"`
+		IPRateLimit               int    `json:"ip_rate_limit"`
+		NamespaceRateLimit        int    `json:"namespace_rate_limit"`
 	}{
-		DatabaseURL:            maskSecret(c.DatabaseURL),
-		RedisAddr:              maskSecret(c.RedisAddr),
-		HTTPAddr:               c.HTTPAddr,
-		TickInterval:           c.TickIntervalStr,
-		DBOpTimeout:            c.DBOpTimeoutStr,
-		DBMaxOpenConns:         c.DBMaxOpenConns,
-		DBMaxIdleConns:         c.DBMaxIdleConns,
-		DBConnMaxLifetime:      c.DBConnMaxLifetimeStr,
-		DBConnMaxIdleTime:      c.DBConnMaxIdleTimeStr,
-		HTTPShutdownTimeout:    c.HTTPShutdownTimeoutStr,
-		DispatcherDrainTimeout: c.DispatcherDrainTimeoutStr,
-		MetricsEnabled:         c.MetricsEnabled,
-		MetricsPath:            c.MetricsPath,
-		ReconcileEnabled:       c.ReconcileEnabled,
-		ReconcileInterval:      c.ReconcileIntervalStr,
+		DatabaseURL:               maskSecret(c.DatabaseURL),
+		RedisAddr:                 maskSecret(c.RedisAddr),
+		HTTPAddr:                  c.HTTPAddr,
+		TickInterval:              c.TickIntervalStr,
+		DBOpTimeout:               c.DBOpTimeoutStr,
+		DBMaxOpenConns:            c.DBMaxOpenConns,
+		DBMaxIdleConns:            c.DBMaxIdleConns,
+		DBConnMaxLifetime:         c.DBConnMaxLifetimeStr,
+		DBConnMaxIdleTime:         c.DBConnMaxIdleTimeStr,
+		HTTPShutdownTimeout:       c.HTTPShutdownTimeoutStr,
+		DispatcherDrainTimeout:    c.DispatcherDrainTimeoutStr,
+		MetricsEnabled:            c.MetricsEnabled,
+		MetricsPath:               c.MetricsPath,
+		MetricsPublic:             c.MetricsPublic,
+		ReconcileEnabled:          c.ReconcileEnabled,
+		ReconcileInterval:         c.ReconcileIntervalStr,
 		ReconcileThreshold:        c.ReconcileThresholdStr,
 		ReconcileRequeueThreshold: c.ReconcileRequeueThresholdStr,
 		ReconcileBatchSize:        c.ReconcileBatchSize,
-		EventBusBufferSize:      c.EventBusBufferSize,
-		CircuitBreakerThreshold: c.CircuitBreakerThreshold,
-		CircuitBreakerCooldown:  c.CircuitBreakerCooldownStr,
-		DispatchMode:            c.DispatchMode,
-		DBPollInterval:          c.DBPollIntervalStr,
-		DispatcherWorkers:       c.DispatcherWorkers,
-		LeaderLockKey:           c.LeaderLockKey,
-		LeaderRetryInterval:     c.LeaderRetryIntervalStr,
-		LeaderHeartbeatInterval: c.LeaderHeartbeatIntervalStr,
-		MaxFiresPerTick:         c.MaxFiresPerTick,
-		IPRateLimit:             c.IPRateLimit,
-		NamespaceRateLimit:      c.NamespaceRateLimit,
+		EventBusBufferSize:        c.EventBusBufferSize,
+		CircuitBreakerThreshold:   c.CircuitBreakerThreshold,
+		CircuitBreakerCooldown:    c.CircuitBreakerCooldownStr,
+		DispatchMode:              c.DispatchMode,
+		DBPollInterval:            c.DBPollIntervalStr,
+		DispatcherWorkers:         c.DispatcherWorkers,
+		LeaderLockKey:             c.LeaderLockKey,
+		LeaderRetryInterval:       c.LeaderRetryIntervalStr,
+		LeaderHeartbeatInterval:   c.LeaderHeartbeatIntervalStr,
+		MaxFiresPerTick:           c.MaxFiresPerTick,
+		IPRateLimit:               c.IPRateLimit,
+		NamespaceRateLimit:        c.NamespaceRateLimit,
 	}
 	return json.MarshalIndent(masked, "", "  ")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -299,6 +299,27 @@ func TestLoad_APIKeyEmpty(t *testing.T) {
 	}
 }
 
+func TestLoad_MetricsPublic(t *testing.T) {
+	os.Setenv("METRICS_PUBLIC", "true")
+	defer os.Unsetenv("METRICS_PUBLIC")
+
+	cfg := Load()
+
+	if !cfg.MetricsPublic {
+		t.Error("MetricsPublic: expected true")
+	}
+}
+
+func TestLoad_MetricsPublicDefaultFalse(t *testing.T) {
+	os.Unsetenv("METRICS_PUBLIC")
+
+	cfg := Load()
+
+	if cfg.MetricsPublic {
+		t.Error("MetricsPublic: expected false")
+	}
+}
+
 func TestMaskedJSON_ExcludesAPIKey(t *testing.T) {
 	os.Setenv("API_KEY", "super-secret")
 	defer os.Unsetenv("API_KEY")


### PR DESCRIPTION
## What

Protect the Prometheus `/metrics` endpoint by default when metrics are enabled.

## Why

The metrics endpoint was only wrapped with auth when the legacy `API_KEY` env var was set. Deployments using namespace-scoped API keys without `API_KEY` could expose `/metrics` publicly.

## How

Added `newMetricsHandler`, which wraps Prometheus metrics with `MultiKeyAuthMiddleware` by default. Added `METRICS_PUBLIC=true` as an explicit opt-in for unauthenticated metrics. Updated config loading, help text, `.env.example`, and regression tests.

## Checklist

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Race detector clean (`go test -race ./...`)
- [x] Documentation updated (if applicable)
- [x] No new security concerns (SSRF, injection, credential exposure)
