### PR TITLE
fix api key namespace scoping

### DIFF
--- a/internal/api/handler_v2.go
+++ b/internal/api/handler_v2.go
@@ -383,12 +383,7 @@ func (s *ServerImpl) AckExecution(ctx context.Context, request AckExecutionReque
 func (s *ServerImpl) CreateAPIKey(ctx context.Context, request CreateAPIKeyRequestObject) (CreateAPIKeyResponseObject, error) {
 	body := request.Body
 
-	// The namespace for the new key comes from the request body.
-	// Override the context namespace with the requested namespace so the
-	// service layer sees the target namespace.
-	nsCtx := domain.NamespaceToContext(ctx, domain.Namespace(body.Namespace))
-
-	result, err := s.svc.CreateAPIKey(nsCtx, service.CreateAPIKeyInput{
+	result, err := s.svc.CreateAPIKey(ctx, service.CreateAPIKeyInput{
 		Label: body.Label,
 	})
 	if err != nil {

--- a/internal/api/handler_v2_test.go
+++ b/internal/api/handler_v2_test.go
@@ -1231,7 +1231,7 @@ func TestAckExecution_NotFound(t *testing.T) {
 
 func TestCreateAPIKey_HappyPath(t *testing.T) {
 	srv := newTestServer(nil, nil, nil, nil, nil, nil)
-	ctx := ctxWithNS("admin")
+	ctx := ctxWithNS("t1")
 
 	resp, err := srv.CreateAPIKey(ctx, CreateAPIKeyRequestObject{
 		Body: &CreateAPIKeyRequest{
@@ -1255,6 +1255,28 @@ func TestCreateAPIKey_HappyPath(t *testing.T) {
 	}
 	if got.Token == "" {
 		t.Fatal("expected token to be non-empty")
+	}
+}
+
+func TestCreateAPIKey_UsesAuthenticatedNamespace(t *testing.T) {
+	srv := newTestServer(nil, nil, nil, nil, nil, nil)
+
+	resp, err := srv.CreateAPIKey(ctxWithNS("caller-ns"), CreateAPIKeyRequestObject{
+		Body: &CreateAPIKeyRequest{
+			Label:     "test-key",
+			Namespace: "other-ns",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, ok := resp.(CreateAPIKey201JSONResponse)
+	if !ok {
+		t.Fatalf("expected CreateAPIKey201JSONResponse, got %T", resp)
+	}
+	if got.Namespace != "caller-ns" {
+		t.Fatalf("expected namespace %q, got %q", "caller-ns", got.Namespace)
 	}
 }
 


### PR DESCRIPTION
## What

Fix API key creation so new keys are always minted in the authenticated caller's namespace.

## Why

`POST /api-keys` previously trusted the request body `namespace` and replaced the authenticated context namespace before calling the service layer. That allowed a caller authenticated for one namespace to create an API key for another namespace.

## How

The API handler now passes the original authenticated request context directly into `CreateAPIKey`, preserving the namespace set by auth middleware. Added a regression test covering a mismatched body namespace to verify the created key uses the caller namespace instead.

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Race detector clean (`go test -race ./...`)
- [ ] Documentation updated (if applicable)
- [x] No new security concerns (SSRF, injection, credential exposure)
