### PR TITLE
Fix scheduler enabled job pagination

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -115,7 +115,7 @@ func main() {
 
 type stubStore struct{}
 
-func (s *stubStore) GetEnabledJobs(ctx context.Context, limit, offset int) ([]domain.JobWithSchedule, error) {
+func (s *stubStore) GetEnabledJobs(ctx context.Context, limit int, afterID uuid.UUID) ([]domain.JobWithSchedule, error) {
 	return nil, nil
 }
 

--- a/internal/api/handler_v2_test.go
+++ b/internal/api/handler_v2_test.go
@@ -23,7 +23,7 @@ type mockJobRepo struct {
 	listJobsFn           func(ctx context.Context, filter domain.JobFilter) ([]domain.Job, error)
 	updateJobFn          func(ctx context.Context, job domain.Job) error
 	deleteJobFn          func(ctx context.Context, id uuid.UUID, ns domain.Namespace) error
-	getEnabledJobsFn     func(ctx context.Context, limit, offset int) ([]domain.JobWithSchedule, error)
+	getEnabledJobsFn     func(ctx context.Context, limit int, afterID uuid.UUID) ([]domain.JobWithSchedule, error)
 }
 
 func (m *mockJobRepo) InsertJob(ctx context.Context, job domain.Job, schedule domain.Schedule) error {
@@ -68,9 +68,9 @@ func (m *mockJobRepo) DeleteJob(ctx context.Context, id uuid.UUID, ns domain.Nam
 	}
 	return nil
 }
-func (m *mockJobRepo) GetEnabledJobs(ctx context.Context, limit, offset int) ([]domain.JobWithSchedule, error) {
+func (m *mockJobRepo) GetEnabledJobs(ctx context.Context, limit int, afterID uuid.UUID) ([]domain.JobWithSchedule, error) {
 	if m.getEnabledJobsFn != nil {
-		return m.getEnabledJobsFn(ctx, limit, offset)
+		return m.getEnabledJobsFn(ctx, limit, afterID)
 	}
 	return nil, nil
 }

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -21,7 +21,7 @@ type JobRepository interface {
 	ListJobs(ctx context.Context, filter JobFilter) ([]Job, error)
 	UpdateJob(ctx context.Context, job Job) error
 	DeleteJob(ctx context.Context, id uuid.UUID, ns Namespace) error
-	GetEnabledJobs(ctx context.Context, limit, offset int) ([]JobWithSchedule, error)
+	GetEnabledJobs(ctx context.Context, limit int, afterID uuid.UUID) ([]JobWithSchedule, error)
 }
 
 type ScheduleRepository interface {

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -24,7 +24,7 @@ type mockJobRepo struct {
 	listJobsFn           func(ctx context.Context, filter domain.JobFilter) ([]domain.Job, error)
 	updateJobFn          func(ctx context.Context, job domain.Job) error
 	deleteJobFn          func(ctx context.Context, id uuid.UUID, ns domain.Namespace) error
-	getEnabledJobsFn     func(ctx context.Context, limit, offset int) ([]domain.JobWithSchedule, error)
+	getEnabledJobsFn     func(ctx context.Context, limit int, afterID uuid.UUID) ([]domain.JobWithSchedule, error)
 }
 
 func (m *mockJobRepo) InsertJob(ctx context.Context, job domain.Job, schedule domain.Schedule) error {
@@ -76,9 +76,9 @@ func (m *mockJobRepo) DeleteJob(ctx context.Context, id uuid.UUID, ns domain.Nam
 	return nil
 }
 
-func (m *mockJobRepo) GetEnabledJobs(ctx context.Context, limit, offset int) ([]domain.JobWithSchedule, error) {
+func (m *mockJobRepo) GetEnabledJobs(ctx context.Context, limit int, afterID uuid.UUID) ([]domain.JobWithSchedule, error) {
 	if m.getEnabledJobsFn != nil {
-		return m.getEnabledJobsFn(ctx, limit, offset)
+		return m.getEnabledJobsFn(ctx, limit, afterID)
 	}
 	return nil, nil
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -20,7 +20,7 @@ const (
 )
 
 type Store interface {
-	GetEnabledJobs(ctx context.Context, limit, offset int) ([]domain.JobWithSchedule, error)
+	GetEnabledJobs(ctx context.Context, limit int, afterID uuid.UUID) ([]domain.JobWithSchedule, error)
 	InsertExecution(ctx context.Context, exec domain.Execution) error
 }
 
@@ -117,10 +117,11 @@ func (s *Scheduler) processTick(ctx context.Context) error {
 	now := start.UTC()
 	jobsTriggered := 0
 
-	// Paginate through all enabled jobs to avoid loading unbounded data into memory.
-	offset := 0
+	// Keyset-paginate enabled jobs to avoid loading unbounded data and to keep
+	// mutable row positions from causing skipped jobs between pages.
+	afterID := uuid.Nil
 	for {
-		jobs, err := s.store.GetEnabledJobs(ctx, DefaultJobPageSize, offset)
+		jobs, err := s.store.GetEnabledJobs(ctx, DefaultJobPageSize, afterID)
 		if err != nil {
 			if s.metrics != nil {
 				s.metrics.TickCompleted(s.clock().Sub(start), jobsTriggered, err)
@@ -140,7 +141,7 @@ func (s *Scheduler) processTick(ctx context.Context) error {
 		if len(jobs) < DefaultJobPageSize {
 			break
 		}
-		offset += len(jobs)
+		afterID = jobs[len(jobs)-1].Job.ID
 	}
 
 	s.lastTick = now

--- a/internal/scheduler/scheduler_extended_test.go
+++ b/internal/scheduler/scheduler_extended_test.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"errors"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ func newMockStoreWithErrors() *mockStoreWithErrors {
 	}
 }
 
-func (s *mockStoreWithErrors) GetEnabledJobs(ctx context.Context, limit, offset int) ([]domain.JobWithSchedule, error) {
+func (s *mockStoreWithErrors) GetEnabledJobs(ctx context.Context, limit int, afterID uuid.UUID) ([]domain.JobWithSchedule, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -36,14 +37,22 @@ func (s *mockStoreWithErrors) GetEnabledJobs(ctx context.Context, limit, offset 
 		return nil, s.getJobsErr
 	}
 
-	if offset >= len(s.jobs) {
-		return nil, nil
+	sortedJobs := append([]domain.JobWithSchedule(nil), s.jobs...)
+	sort.Slice(sortedJobs, func(i, j int) bool {
+		return sortedJobs[i].Job.ID.String() < sortedJobs[j].Job.ID.String()
+	})
+
+	var jobs []domain.JobWithSchedule
+	for i := range sortedJobs {
+		if afterID != uuid.Nil && sortedJobs[i].Job.ID.String() <= afterID.String() {
+			continue
+		}
+		jobs = append(jobs, sortedJobs[i])
+		if len(jobs) == limit {
+			break
+		}
 	}
-	end := offset + limit
-	if end > len(s.jobs) {
-		end = len(s.jobs)
-	}
-	return s.jobs[offset:end], nil
+	return jobs, nil
 }
 
 func (s *mockStoreWithErrors) InsertExecution(ctx context.Context, exec domain.Execution) error {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"errors"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -19,11 +20,12 @@ type mockStore struct {
 	jobs         []domain.JobWithSchedule
 	getJobsCalls []getJobsCall // tracks pagination calls
 	getJobsErr   error         // if set, GetEnabledJobs returns this error
+	afterGetJobs func(*mockStore, getJobsCall)
 }
 
 type getJobsCall struct {
-	limit  int
-	offset int
+	limit   int
+	afterID uuid.UUID
 }
 
 func newMockStore() *mockStore {
@@ -32,24 +34,36 @@ func newMockStore() *mockStore {
 	}
 }
 
-func (s *mockStore) GetEnabledJobs(ctx context.Context, limit, offset int) ([]domain.JobWithSchedule, error) {
+func (s *mockStore) GetEnabledJobs(ctx context.Context, limit int, afterID uuid.UUID) ([]domain.JobWithSchedule, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.getJobsCalls = append(s.getJobsCalls, getJobsCall{limit: limit, offset: offset})
+	call := getJobsCall{limit: limit, afterID: afterID}
+	s.getJobsCalls = append(s.getJobsCalls, call)
 
 	if s.getJobsErr != nil {
 		return nil, s.getJobsErr
 	}
 
-	if offset >= len(s.jobs) {
-		return nil, nil
+	sortedJobs := append([]domain.JobWithSchedule(nil), s.jobs...)
+	sort.Slice(sortedJobs, func(i, j int) bool {
+		return sortedJobs[i].Job.ID.String() < sortedJobs[j].Job.ID.String()
+	})
+
+	var jobs []domain.JobWithSchedule
+	for i := range sortedJobs {
+		if afterID != uuid.Nil && sortedJobs[i].Job.ID.String() <= afterID.String() {
+			continue
+		}
+		jobs = append(jobs, sortedJobs[i])
+		if len(jobs) == limit {
+			break
+		}
 	}
-	end := offset + limit
-	if end > len(s.jobs) {
-		end = len(s.jobs)
+	if s.afterGetJobs != nil {
+		s.afterGetJobs(s, call)
 	}
-	return s.jobs[offset:end], nil
+	return jobs, nil
 }
 
 func (s *mockStore) InsertExecution(ctx context.Context, exec domain.Execution) error {
@@ -527,8 +541,7 @@ func TestScheduler_Pagination(t *testing.T) {
 		t.Fatalf("processTick failed: %v", err)
 	}
 
-	// Verify pagination happened: should have 3 pages of calls
-	// Page 1: offset=0, Page 2: offset=100, Page 3: offset=200
+	// Verify pagination happened: should have 3 pages of calls.
 	store.mu.Lock()
 	calls := store.getJobsCalls
 	store.mu.Unlock()
@@ -537,14 +550,15 @@ func TestScheduler_Pagination(t *testing.T) {
 		t.Errorf("expected 3 pagination calls, got %d", len(calls))
 	}
 
-	// Verify offsets
-	expectedOffsets := []int{0, 100, 200}
-	for i, expected := range expectedOffsets {
+	for i := range calls {
 		if i >= len(calls) {
 			break
 		}
-		if calls[i].offset != expected {
-			t.Errorf("call %d: expected offset %d, got %d", i, expected, calls[i].offset)
+		if i == 0 && calls[i].afterID != uuid.Nil {
+			t.Errorf("call %d: expected empty cursor, got %s", i, calls[i].afterID)
+		}
+		if i > 0 && calls[i].afterID == uuid.Nil {
+			t.Errorf("call %d: expected non-empty cursor", i)
 		}
 		if calls[i].limit != DefaultJobPageSize {
 			t.Errorf("call %d: expected limit %d, got %d", i, DefaultJobPageSize, calls[i].limit)
@@ -554,6 +568,61 @@ func TestScheduler_Pagination(t *testing.T) {
 	// Verify all jobs were processed
 	if store.executionCount() != numJobs {
 		t.Errorf("expected %d executions, got %d", numJobs, store.executionCount())
+	}
+}
+
+func TestScheduler_PaginationDoesNotSkipWhenEnabledSetShrinksBetweenPages(t *testing.T) {
+	store := newMockStore()
+	emitter := &mockEmitter{}
+
+	fireTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	numJobs := DefaultJobPageSize + 1
+	for i := 0; i < numJobs; i++ {
+		jobID := uuid.New()
+		scheduleID := uuid.New()
+		store.addJob(
+			domain.Job{
+				ID:         jobID,
+				Namespace:  domain.Namespace("test-ns"),
+				Name:       "test-job",
+				Enabled:    true,
+				ScheduleID: scheduleID,
+			},
+			domain.Schedule{
+				ID:             scheduleID,
+				CronExpression: "0 * * * *",
+				Timezone:       "UTC",
+			},
+		)
+	}
+	store.afterGetJobs = func(s *mockStore, call getJobsCall) {
+		if call.afterID == uuid.Nil {
+			sort.Slice(s.jobs, func(i, j int) bool {
+				return s.jobs[i].Job.ID.String() < s.jobs[j].Job.ID.String()
+			})
+			s.jobs = s.jobs[1:]
+		}
+	}
+
+	parser := &mockCronParser{fireTimes: []time.Time{fireTime}}
+
+	sched := New(
+		Config{TickInterval: time.Minute},
+		store,
+		parser,
+		emitter,
+	)
+
+	sched.clock = func() time.Time { return fireTime.Add(30 * time.Second) }
+	sched.lastTick = fireTime.Add(-time.Minute)
+
+	if err := sched.processTick(context.Background()); err != nil {
+		t.Fatalf("processTick failed: %v", err)
+	}
+
+	if store.executionCount() != numJobs {
+		t.Fatalf("expected all %d jobs to be processed, got %d", numJobs, store.executionCount())
 	}
 }
 

--- a/internal/service/jobs_test.go
+++ b/internal/service/jobs_test.go
@@ -21,7 +21,7 @@ type mockJobRepo struct {
 	listJobsFn                 func(ctx context.Context, filter domain.JobFilter) ([]domain.Job, error)
 	updateJobFn                func(ctx context.Context, job domain.Job) error
 	deleteJobFn                func(ctx context.Context, id uuid.UUID, ns domain.Namespace) error
-	getEnabledJobsFn           func(ctx context.Context, limit, offset int) ([]domain.JobWithSchedule, error)
+	getEnabledJobsFn           func(ctx context.Context, limit int, afterID uuid.UUID) ([]domain.JobWithSchedule, error)
 
 	// capture last call
 	lastInsertedJob domain.Job
@@ -83,9 +83,9 @@ func (m *mockJobRepo) DeleteJob(ctx context.Context, id uuid.UUID, ns domain.Nam
 	return nil
 }
 
-func (m *mockJobRepo) GetEnabledJobs(ctx context.Context, limit, offset int) ([]domain.JobWithSchedule, error) {
+func (m *mockJobRepo) GetEnabledJobs(ctx context.Context, limit int, afterID uuid.UUID) ([]domain.JobWithSchedule, error) {
 	if m.getEnabledJobsFn != nil {
-		return m.getEnabledJobsFn(ctx, limit, offset)
+		return m.getEnabledJobsFn(ctx, limit, afterID)
 	}
 	return nil, nil
 }

--- a/internal/store/postgres/queries.go
+++ b/internal/store/postgres/queries.go
@@ -12,8 +12,9 @@ SELECT
 FROM jobs j
 JOIN schedules s ON j.schedule_id = s.id
 WHERE j.enabled = true
+  AND ($2 = '00000000-0000-0000-0000-000000000000'::uuid OR j.id > $2)
 ORDER BY j.id
-LIMIT $1 OFFSET $2
+LIMIT $1
 `
 
 const queryInsertJob = `

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -41,12 +41,12 @@ func (s *Store) withTimeout(parent context.Context) (context.Context, context.Ca
 
 // ── Job Repository ────────────────────────────────────────────────────────────
 
-// GetEnabledJobs returns enabled jobs with their schedules, paginated by limit and offset.
-func (s *Store) GetEnabledJobs(ctx context.Context, limit, offset int) ([]domain.JobWithSchedule, error) {
+// GetEnabledJobs returns enabled jobs with their schedules after afterID, ordered by job ID.
+func (s *Store) GetEnabledJobs(ctx context.Context, limit int, afterID uuid.UUID) ([]domain.JobWithSchedule, error) {
 	ctx, cancel := s.withTimeout(ctx)
 	defer cancel()
 
-	rows, err := s.db.QueryContext(ctx, queryGetEnabledJobs, limit, offset)
+	rows, err := s.db.QueryContext(ctx, queryGetEnabledJobs, limit, afterID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What

Fixes scheduler enabled-job pagination to use keyset pagination instead of offset pagination.

## Why

Offset pagination over `WHERE enabled = true ORDER BY id` can skip jobs if the enabled job set changes between pages during a scheduler tick.

## How

`GetEnabledJobs` now accepts an `afterID` cursor. The scheduler advances that cursor using the last job ID from each page, and the Postgres query fetches `j.id > afterID ORDER BY j.id LIMIT $1`. Added a regression test for an enabled-set shrink between pages.

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Race detector clean (`go test -race ./...`)
- [ ] Documentation updated (if applicable)
- [x] No new security concerns (SSRF, injection, credential exposure)