### PR TITLE
Add production configuration validation

### DIFF
--- a/OPERATORS.md
+++ b/OPERATORS.md
@@ -56,9 +56,11 @@ Max shutdown time: `DISPATCHER_DRAIN_TIMEOUT` + `HTTP_SHUTDOWN_TIMEOUT` (default
 ## Production Checklist
 
 - [ ] All migrations applied in order (see [Migrations](#migrations))
+- [ ] `CRONLITE_ENV=production` set so unsafe production configuration fails startup
+- [ ] `DISPATCH_MODE=db` on all production instances
 - [ ] `RECONCILE_ENABLED=true` on all instances
 - [ ] `METRICS_ENABLED=true` on all instances
-- [ ] `DISPATCH_MODE=db` if running more than one instance
+- [ ] `API_KEY` set for production startup validation, even if traffic uses namespace-scoped API keys
 - [ ] `LEADER_LOCK_KEY` identical across all instances (default: 728379)
 - [ ] `DISPATCHER_WORKERS` set to 2-4 for production workloads
 - [ ] Postgres TCP keepalive tuned: `tcp_keepalives_idle=10`, `tcp_keepalives_interval=5`, `tcp_keepalives_count=3`
@@ -76,6 +78,7 @@ Max shutdown time: `DISPATCHER_DRAIN_TIMEOUT` + `HTTP_SHUTDOWN_TIMEOUT` (default
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `CRONLITE_ENV` | *(empty)* | Set to `production` to fail startup on unsafe production settings |
 | `DATABASE_URL` | *required* | PostgreSQL connection string |
 | `API_KEY` | *(empty)* | Legacy static Bearer token fallback (also used to protect `/metrics` when set) |
 | `HTTP_ADDR` | `:8080` | Listen address |
@@ -109,8 +112,11 @@ Max shutdown time: `DISPATCHER_DRAIN_TIMEOUT` + `HTTP_SHUTDOWN_TIMEOUT` (default
 
 | Variable | Value | Why |
 |----------|-------|-----|
+| `CRONLITE_ENV` | `production` | Enables strict production validation before startup |
+| `DISPATCH_MODE` | `db` | Avoids in-memory dispatch loss and supports multi-instance coordination |
 | `RECONCILE_ENABLED` | `true` | Without this, orphaned executions are **permanently lost** |
 | `METRICS_ENABLED` | `true` | Required for observability and alerting |
+| `API_KEY` | non-empty | Ensures API authentication is configured at startup |
 
 ## Guarantees
 

--- a/cmd/cronlite/main.go
+++ b/cmd/cronlite/main.go
@@ -112,6 +112,7 @@ Commands:
   create-key   Create a new API key  (usage: cronlite create-key <namespace> <label>)
 
 Environment Variables:
+  CRONLITE_ENV              Runtime environment; "production" enables strict validation
   DATABASE_URL              PostgreSQL connection string (required)
   REDIS_ADDR                Redis address for analytics (optional)
   HTTP_ADDR                 HTTP server address (default: ":8080")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 // Config holds all configuration for the cronlite application.
 // Values are loaded from environment variables; see printUsage() for the full list.
 type Config struct {
+	Environment string `json:"environment,omitempty"`
 	DatabaseURL string `json:"database_url"`
 	RedisAddr   string `json:"redis_addr,omitempty"`
 	HTTPAddr    string `json:"http_addr"`
@@ -91,6 +92,7 @@ type Config struct {
 // Load reads configuration from environment variables with defaults.
 func Load() Config {
 	cfg := Config{
+		Environment:                  os.Getenv("CRONLITE_ENV"),
 		DatabaseURL:                  os.Getenv("DATABASE_URL"),
 		RedisAddr:                    os.Getenv("REDIS_ADDR"),
 		HTTPAddr:                     os.Getenv("HTTP_ADDR"),
@@ -337,6 +339,7 @@ func parseInt(s string) (int, error) {
 // MaskedJSON returns the configuration as JSON with secrets masked.
 func (c Config) MaskedJSON() ([]byte, error) {
 	masked := struct {
+		Environment               string `json:"environment,omitempty"`
 		DatabaseURL               string `json:"database_url"`
 		RedisAddr                 string `json:"redis_addr,omitempty"`
 		HTTPAddr                  string `json:"http_addr"`
@@ -369,6 +372,7 @@ func (c Config) MaskedJSON() ([]byte, error) {
 		IPRateLimit               int    `json:"ip_rate_limit"`
 		NamespaceRateLimit        int    `json:"namespace_rate_limit"`
 	}{
+		Environment:               c.Environment,
 		DatabaseURL:               maskSecret(c.DatabaseURL),
 		RedisAddr:                 maskSecret(c.RedisAddr),
 		HTTPAddr:                  c.HTTPAddr,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -289,6 +289,17 @@ func TestLoad_APIKey(t *testing.T) {
 	}
 }
 
+func TestLoad_Environment(t *testing.T) {
+	os.Setenv("CRONLITE_ENV", "production")
+	defer os.Unsetenv("CRONLITE_ENV")
+
+	cfg := Load()
+
+	if cfg.Environment != "production" {
+		t.Errorf("Environment: expected 'production', got %q", cfg.Environment)
+	}
+}
+
 func TestLoad_APIKeyEmpty(t *testing.T) {
 	os.Unsetenv("API_KEY")
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/djlord-it/cronlite/internal/dispatcher"
@@ -132,8 +133,43 @@ func Validate(cfg Config) error {
 		})
 	}
 
+	if strings.EqualFold(cfg.Environment, "production") {
+		errs = append(errs, validateProduction(cfg)...)
+	}
+
 	if len(errs) > 0 {
 		return errs
 	}
 	return nil
+}
+
+func validateProduction(cfg Config) ValidationErrors {
+	var errs ValidationErrors
+
+	if cfg.DispatchMode != "db" {
+		errs = append(errs, ValidationError{
+			Field:   "DISPATCH_MODE",
+			Message: "must be 'db' when CRONLITE_ENV=production",
+		})
+	}
+	if !cfg.ReconcileEnabled {
+		errs = append(errs, ValidationError{
+			Field:   "RECONCILE_ENABLED",
+			Message: "must be true when CRONLITE_ENV=production",
+		})
+	}
+	if !cfg.MetricsEnabled {
+		errs = append(errs, ValidationError{
+			Field:   "METRICS_ENABLED",
+			Message: "must be true when CRONLITE_ENV=production",
+		})
+	}
+	if cfg.APIKey == "" {
+		errs = append(errs, ValidationError{
+			Field:   "API_KEY",
+			Message: "required when CRONLITE_ENV=production",
+		})
+	}
+
+	return errs
 }

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -148,11 +148,11 @@ func TestValidationErrors_Format(t *testing.T) {
 // validDBConfig returns a minimal valid Config for DB dispatch mode.
 func validDBConfig() Config {
 	return Config{
-		DatabaseURL:             "postgres://localhost/test",
-		DispatchMode:            "db",
-		LeaderRetryInterval:     5 * time.Second,
-		LeaderRetryIntervalStr:  "5s",
-		LeaderHeartbeatInterval: 2 * time.Second,
+		DatabaseURL:                "postgres://localhost/test",
+		DispatchMode:               "db",
+		LeaderRetryInterval:        5 * time.Second,
+		LeaderRetryIntervalStr:     "5s",
+		LeaderHeartbeatInterval:    2 * time.Second,
 		LeaderHeartbeatIntervalStr: "2s",
 	}
 }
@@ -214,9 +214,9 @@ func TestValidate_ReconcileThresholdSafe(t *testing.T) {
 
 func TestValidate_CircuitBreakerCooldownRequired(t *testing.T) {
 	cfg := Config{
-		DatabaseURL:              "postgres://localhost/test",
-		CircuitBreakerThreshold:  5,
-		CircuitBreakerCooldown:   -1 * time.Second,
+		DatabaseURL:               "postgres://localhost/test",
+		CircuitBreakerThreshold:   5,
+		CircuitBreakerCooldown:    -1 * time.Second,
 		CircuitBreakerCooldownStr: "-1s",
 	}
 
@@ -226,5 +226,63 @@ func TestValidate_CircuitBreakerCooldownRequired(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "CIRCUIT_BREAKER_COOLDOWN") {
 		t.Errorf("error should mention CIRCUIT_BREAKER_COOLDOWN: %q", err)
+	}
+}
+
+func TestValidate_ProductionRequiresSafeRuntimeSettings(t *testing.T) {
+	cfg := validDBConfig()
+	cfg.Environment = "production"
+	cfg.DispatchMode = "channel"
+	cfg.ReconcileEnabled = false
+	cfg.MetricsEnabled = false
+	cfg.APIKey = ""
+
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected production validation errors")
+	}
+
+	for _, want := range []string{
+		"DISPATCH_MODE",
+		"RECONCILE_ENABLED",
+		"METRICS_ENABLED",
+		"API_KEY",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected production validation error to mention %s, got: %v", want, err)
+		}
+	}
+}
+
+func TestValidate_ProductionValidConfig(t *testing.T) {
+	cfg := validDBConfig()
+	cfg.Environment = "production"
+	cfg.ReconcileEnabled = true
+	cfg.ReconcileInterval = 5 * time.Minute
+	cfg.ReconcileIntervalStr = "5m"
+	cfg.ReconcileThreshold = 15 * time.Minute
+	cfg.ReconcileThresholdStr = "15m"
+	cfg.ReconcileRequeueThreshold = 2 * time.Minute
+	cfg.ReconcileRequeueThresholdStr = "2m"
+	cfg.MetricsEnabled = true
+	cfg.APIKey = "prod-key"
+
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("expected valid production config, got: %v", err)
+	}
+}
+
+func TestValidate_DevelopmentAllowsUnsafeRuntimeSettings(t *testing.T) {
+	cfg := Config{
+		Environment:      "development",
+		DatabaseURL:      "postgres://localhost/test",
+		DispatchMode:     "channel",
+		ReconcileEnabled: false,
+		MetricsEnabled:   false,
+		APIKey:           "",
+	}
+
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("expected development config to remain valid, got: %v", err)
 	}
 }


### PR DESCRIPTION
## What

Adds strict production configuration validation via `CRONLITE_ENV=production`.

## Why

CronLite could previously start in production with unsafe settings like channel dispatch, reconciler disabled, metrics disabled, or no configured API authentication.

## How

`Config` now loads `CRONLITE_ENV`. When set to `production`, validation requires `DATABASE_URL`, `DISPATCH_MODE=db`, `RECONCILE_ENABLED=true`, `METRICS_ENABLED=true`, and a non-empty `API_KEY`. Dev/local mode keeps the existing permissive warning behavior. Updated CLI help and operator docs.

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Race detector clean (`go test -race ./...`)
- [x] Documentation updated (if applicable)
- [x] No new security concerns (SSRF, injection, credential exposure)