### PR TITLE
Make job updates atomic

### DIFF
--- a/internal/api/handler_v2_test.go
+++ b/internal/api/handler_v2_test.go
@@ -62,6 +62,12 @@ func (m *mockJobRepo) UpdateJob(ctx context.Context, job domain.Job) error {
 	}
 	return nil
 }
+func (m *mockJobRepo) UpdateJobAggregate(ctx context.Context, job domain.Job, schedule domain.Schedule, tags *[]domain.Tag) error {
+	if m.updateJobFn != nil {
+		return m.updateJobFn(ctx, job)
+	}
+	return nil
+}
 func (m *mockJobRepo) DeleteJob(ctx context.Context, id uuid.UUID, ns domain.Namespace) error {
 	if m.deleteJobFn != nil {
 		return m.deleteJobFn(ctx, id, ns)

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -20,6 +20,7 @@ type JobRepository interface {
 	GetJobWithScheduleScoped(ctx context.Context, id uuid.UUID, ns Namespace) (Job, Schedule, error)
 	ListJobs(ctx context.Context, filter JobFilter) ([]Job, error)
 	UpdateJob(ctx context.Context, job Job) error
+	UpdateJobAggregate(ctx context.Context, job Job, schedule Schedule, tags *[]Tag) error
 	DeleteJob(ctx context.Context, id uuid.UUID, ns Namespace) error
 	GetEnabledJobs(ctx context.Context, limit int, afterID uuid.UUID) ([]JobWithSchedule, error)
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -69,6 +69,13 @@ func (m *mockJobRepo) UpdateJob(ctx context.Context, job domain.Job) error {
 	return nil
 }
 
+func (m *mockJobRepo) UpdateJobAggregate(ctx context.Context, job domain.Job, schedule domain.Schedule, tags *[]domain.Tag) error {
+	if m.updateJobFn != nil {
+		return m.updateJobFn(ctx, job)
+	}
+	return nil
+}
+
 func (m *mockJobRepo) DeleteJob(ctx context.Context, id uuid.UUID, ns domain.Namespace) error {
 	if m.deleteJobFn != nil {
 		return m.deleteJobFn(ctx, id, ns)

--- a/internal/service/jobs.go
+++ b/internal/service/jobs.go
@@ -206,27 +206,11 @@ func (s *JobService) UpdateJob(ctx context.Context, id uuid.UUID, input UpdateJo
 		schedule.CronExpression = cronExpr
 		schedule.Timezone = tz
 		schedule.UpdatedAt = now
-
-		if err := s.schedules.UpdateSchedule(ctx, schedule); err != nil {
-			return domain.Job{}, domain.Schedule{}, fmt.Errorf("update schedule: %w", err)
-		}
 	}
 
 	job.UpdatedAt = now
-	if err := s.jobs.UpdateJob(ctx, job); err != nil {
-		return domain.Job{}, domain.Schedule{}, fmt.Errorf("update job: %w", err)
-	}
-
-	// If tags changed, delete and re-upsert.
-	if input.Tags != nil {
-		if err := s.tags.DeleteTags(ctx, id); err != nil {
-			return domain.Job{}, domain.Schedule{}, fmt.Errorf("delete tags: %w", err)
-		}
-		if len(*input.Tags) > 0 {
-			if err := s.tags.UpsertTags(ctx, id, *input.Tags); err != nil {
-				return domain.Job{}, domain.Schedule{}, fmt.Errorf("upsert tags: %w", err)
-			}
-		}
+	if err := s.jobs.UpdateJobAggregate(ctx, job, schedule, input.Tags); err != nil {
+		return domain.Job{}, domain.Schedule{}, fmt.Errorf("update job aggregate: %w", err)
 	}
 
 	return job, schedule, nil

--- a/internal/service/jobs_test.go
+++ b/internal/service/jobs_test.go
@@ -20,12 +20,16 @@ type mockJobRepo struct {
 	getJobWithScheduleScopedFn func(ctx context.Context, id uuid.UUID, ns domain.Namespace) (domain.Job, domain.Schedule, error)
 	listJobsFn                 func(ctx context.Context, filter domain.JobFilter) ([]domain.Job, error)
 	updateJobFn                func(ctx context.Context, job domain.Job) error
+	updateJobAggregateFn       func(ctx context.Context, job domain.Job, schedule domain.Schedule, tags *[]domain.Tag) error
 	deleteJobFn                func(ctx context.Context, id uuid.UUID, ns domain.Namespace) error
 	getEnabledJobsFn           func(ctx context.Context, limit int, afterID uuid.UUID) ([]domain.JobWithSchedule, error)
 
 	// capture last call
-	lastInsertedJob domain.Job
-	lastUpdatedJob  domain.Job
+	lastInsertedJob       domain.Job
+	lastUpdatedJob        domain.Job
+	lastAggregateJob      domain.Job
+	lastAggregateSchedule domain.Schedule
+	lastAggregateTags     *[]domain.Tag
 }
 
 func (m *mockJobRepo) InsertJob(ctx context.Context, job domain.Job, schedule domain.Schedule) error {
@@ -72,6 +76,17 @@ func (m *mockJobRepo) UpdateJob(ctx context.Context, job domain.Job) error {
 	m.lastUpdatedJob = job
 	if m.updateJobFn != nil {
 		return m.updateJobFn(ctx, job)
+	}
+	return nil
+}
+
+func (m *mockJobRepo) UpdateJobAggregate(ctx context.Context, job domain.Job, schedule domain.Schedule, tags *[]domain.Tag) error {
+	m.lastUpdatedJob = job
+	m.lastAggregateJob = job
+	m.lastAggregateSchedule = schedule
+	m.lastAggregateTags = tags
+	if m.updateJobAggregateFn != nil {
+		return m.updateJobAggregateFn(ctx, job, schedule, tags)
 	}
 	return nil
 }
@@ -708,7 +723,6 @@ func TestUpdateJob_HappyPath(t *testing.T) {
 func TestUpdateJob_ScheduleChanged(t *testing.T) {
 	jobID := uuid.New()
 	schedID := uuid.New()
-	var scheduleUpdated bool
 	jobRepo := &mockJobRepo{
 		getJobWithScheduleFn: func(_ context.Context, id uuid.UUID) (domain.Job, domain.Schedule, error) {
 			return domain.Job{
@@ -717,27 +731,18 @@ func TestUpdateJob_ScheduleChanged(t *testing.T) {
 			}, domain.Schedule{ID: schedID, CronExpression: "*/5 * * * *", Timezone: "UTC"}, nil
 		},
 	}
-	schedRepo := &mockScheduleRepo{
-		updateScheduleFn: func(_ context.Context, schedule domain.Schedule) error {
-			scheduleUpdated = true
-			if schedule.CronExpression != "*/10 * * * *" {
-				t.Errorf("expected cron '*/10 * * * *', got %q", schedule.CronExpression)
-			}
-			return nil
-		},
-	}
-	svc := newTestServiceFull(jobRepo, schedRepo, nil, nil, nil, nil)
+	svc := newTestService(jobRepo)
 
 	newCron := "*/10 * * * *"
 	_, sched, err := svc.UpdateJob(ctxWithNS("t1"), jobID, UpdateJobInput{CronExpression: &newCron})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !scheduleUpdated {
-		t.Error("expected schedule to be updated")
-	}
 	if sched.CronExpression != "*/10 * * * *" {
 		t.Errorf("expected new cron '*/10 * * * *', got %q", sched.CronExpression)
+	}
+	if jobRepo.lastAggregateSchedule.CronExpression != "*/10 * * * *" {
+		t.Errorf("expected aggregate cron '*/10 * * * *', got %q", jobRepo.lastAggregateSchedule.CronExpression)
 	}
 }
 
@@ -822,38 +827,75 @@ func TestUpdateJob_WithTags(t *testing.T) {
 		},
 	}
 
-	var deleteCalled, upsertCalled bool
-	tagRepo := &mockTagRepo{
-		deleteTagsFn: func(_ context.Context, id uuid.UUID) error {
-			deleteCalled = true
-			if id != jobID {
-				t.Errorf("expected delete for job %s, got %s", jobID, id)
-			}
-			return nil
-		},
-		upsertTagsFn: func(_ context.Context, id uuid.UUID, tags []domain.Tag) error {
-			upsertCalled = true
-			if id != jobID {
-				t.Errorf("expected upsert for job %s, got %s", jobID, id)
-			}
-			if len(tags) != 2 {
-				t.Errorf("expected 2 tags, got %d", len(tags))
-			}
-			return nil
-		},
-	}
-	svc := newTestServiceFull(jobRepo, nil, nil, tagRepo, nil, nil)
+	svc := newTestService(jobRepo)
 
 	newTags := []domain.Tag{{Key: "env", Value: "prod"}, {Key: "team", Value: "backend"}}
 	_, _, err := svc.UpdateJob(ctxWithNS("t1"), jobID, UpdateJobInput{Tags: &newTags})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !deleteCalled {
-		t.Error("expected DeleteTags to be called")
+	if jobRepo.lastAggregateTags == nil {
+		t.Fatal("expected aggregate tags to be set")
 	}
-	if !upsertCalled {
-		t.Error("expected UpsertTags to be called")
+	if len(*jobRepo.lastAggregateTags) != 2 {
+		t.Fatalf("expected 2 aggregate tags, got %d", len(*jobRepo.lastAggregateTags))
+	}
+}
+
+func TestUpdateJob_UsesAtomicAggregateUpdate(t *testing.T) {
+	jobID := uuid.New()
+	schedID := uuid.New()
+	newTags := []domain.Tag{{Key: "env", Value: "prod"}}
+	newCron := "*/10 * * * *"
+	newName := "new-name"
+	var aggregateCalled bool
+
+	jobRepo := &mockJobRepo{
+		getJobWithScheduleFn: func(_ context.Context, id uuid.UUID) (domain.Job, domain.Schedule, error) {
+			return domain.Job{
+				ID: jobID, Namespace: "t1", Name: "old-name", ScheduleID: schedID, Enabled: true,
+				Delivery: domain.DeliveryConfig{WebhookURL: "https://example.com", Timeout: 30 * time.Second},
+			}, domain.Schedule{ID: schedID, CronExpression: "*/5 * * * *", Timezone: "UTC"}, nil
+		},
+		updateJobAggregateFn: func(_ context.Context, job domain.Job, schedule domain.Schedule, tags *[]domain.Tag) error {
+			aggregateCalled = true
+			if job.Name != newName {
+				t.Errorf("aggregate job name = %q, want %q", job.Name, newName)
+			}
+			if schedule.CronExpression != newCron {
+				t.Errorf("aggregate cron = %q, want %q", schedule.CronExpression, newCron)
+			}
+			if tags == nil || len(*tags) != 1 || (*tags)[0] != newTags[0] {
+				t.Errorf("aggregate tags = %#v, want %#v", tags, newTags)
+			}
+			return nil
+		},
+	}
+	schedRepo := &mockScheduleRepo{
+		updateScheduleFn: func(_ context.Context, _ domain.Schedule) error {
+			return errors.New("separate schedule update should not be called")
+		},
+	}
+	tagRepo := &mockTagRepo{
+		deleteTagsFn: func(_ context.Context, _ uuid.UUID) error {
+			return errors.New("separate tag delete should not be called")
+		},
+		upsertTagsFn: func(_ context.Context, _ uuid.UUID, _ []domain.Tag) error {
+			return errors.New("separate tag upsert should not be called")
+		},
+	}
+	svc := newTestServiceFull(jobRepo, schedRepo, nil, tagRepo, nil, nil)
+
+	_, _, err := svc.UpdateJob(ctxWithNS("t1"), jobID, UpdateJobInput{
+		Name:           &newName,
+		CronExpression: &newCron,
+		Tags:           &newTags,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !aggregateCalled {
+		t.Fatal("expected UpdateJobAggregate to be called")
 	}
 }
 

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -347,6 +347,67 @@ func (s *Store) UpdateJob(ctx context.Context, job domain.Job) error {
 	return nil
 }
 
+// UpdateJobAggregate updates a job, its schedule, and optionally replaces tags atomically.
+func (s *Store) UpdateJobAggregate(ctx context.Context, job domain.Job, schedule domain.Schedule, tags *[]domain.Tag) error {
+	ctx, cancel := s.withTimeout(ctx)
+	defer cancel()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	if _, err := tx.ExecContext(ctx, queryUpdateSchedule,
+		schedule.CronExpression,
+		schedule.Timezone,
+		schedule.UpdatedAt,
+		schedule.ID,
+	); err != nil {
+		return err
+	}
+
+	result, err := tx.ExecContext(ctx, queryUpdateJob,
+		job.Name,
+		job.Enabled,
+		string(job.Delivery.Type),
+		job.Delivery.WebhookURL,
+		job.Delivery.Secret,
+		job.Delivery.Timeout.Milliseconds(),
+		job.Analytics.Enabled,
+		job.Analytics.RetentionSeconds,
+		job.UpdatedAt,
+		job.ID,
+		string(job.Namespace),
+	)
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return domain.ErrJobNotFound
+	}
+
+	if tags != nil {
+		if _, err := tx.ExecContext(ctx, queryDeleteTags, job.ID); err != nil {
+			return err
+		}
+		for _, tag := range *tags {
+			if _, err := tx.ExecContext(ctx, queryUpsertTag, job.ID, tag.Key, tag.Value); err != nil {
+				return err
+			}
+		}
+	}
+
+	return tx.Commit()
+}
+
 // DeleteJob cascade-deletes a job by id and namespace.
 func (s *Store) DeleteJob(ctx context.Context, jobID uuid.UUID, ns domain.Namespace) error {
 	ctx, cancel := s.withTimeout(ctx)

--- a/internal/store/postgres/update_job_aggregate_test.go
+++ b/internal/store/postgres/update_job_aggregate_test.go
@@ -1,0 +1,84 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+
+	"github.com/djlord-it/cronlite/internal/domain"
+)
+
+func TestUpdateJobAggregate_RollsBackWhenTagUpsertFails(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	store := New(db, 0)
+	now := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	jobID := uuid.New()
+	scheduleID := uuid.New()
+	job := domain.Job{
+		ID:         jobID,
+		Namespace:  domain.Namespace("tenant-1"),
+		Name:       "updated",
+		Enabled:    true,
+		ScheduleID: scheduleID,
+		Delivery: domain.DeliveryConfig{
+			Type:       domain.DeliveryTypeWebhook,
+			WebhookURL: "https://example.com/hook",
+			Secret:     "secret",
+			Timeout:    30 * time.Second,
+		},
+		Analytics: domain.AnalyticsConfig{RetentionSeconds: domain.DefaultRetentionSeconds},
+		UpdatedAt: now,
+	}
+	schedule := domain.Schedule{
+		ID:             scheduleID,
+		CronExpression: "*/10 * * * *",
+		Timezone:       "UTC",
+		UpdatedAt:      now,
+	}
+	tags := []domain.Tag{{Key: "env", Value: "prod"}}
+	tagErr := errors.New("tag insert failed")
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE schedules SET").
+		WithArgs(schedule.CronExpression, schedule.Timezone, schedule.UpdatedAt, schedule.ID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE jobs SET").
+		WithArgs(
+			job.Name,
+			job.Enabled,
+			string(job.Delivery.Type),
+			job.Delivery.WebhookURL,
+			job.Delivery.Secret,
+			job.Delivery.Timeout.Milliseconds(),
+			job.Analytics.Enabled,
+			job.Analytics.RetentionSeconds,
+			job.UpdatedAt,
+			job.ID,
+			string(job.Namespace),
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM tags").WithArgs(job.ID).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO tags").WithArgs(job.ID, tags[0].Key, tags[0].Value).WillReturnError(tagErr)
+	mock.ExpectRollback()
+
+	err = store.UpdateJobAggregate(context.Background(), job, schedule, &tags)
+	if err == nil {
+		t.Fatal("expected tag upsert error")
+	}
+	if !strings.Contains(err.Error(), tagErr.Error()) {
+		t.Fatalf("expected error %q, got %v", tagErr, err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Makes job updates atomic across job, schedule, and tag changes.

## Why

Previously, `UpdateJob` applied schedule, job row, and tag updates through separate repository calls. If a later operation failed, earlier changes could remain persisted, leaving a partially updated job.

## How

Added `UpdateJobAggregate` to the job repository and implemented it in Postgres with a single transaction. `JobService.UpdateJob` now validates/builds the updated aggregate, then commits schedule, job, tag delete, and tag upsert together. Added a rollback test for tag upsert failure.

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Race detector clean (`go test -race ./...`)
- [ ] Documentation updated (if applicable)
- [x] No new security concerns (SSRF, injection, credential exposure)